### PR TITLE
proposed: change max line length in pycodestyle, document it

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,6 @@
+
+Developer Readme
+
+
+- run tests: python setup.py test (yes, this is deprecated)
+- style is enforced with pycodestyle, mostly using default settings. https://www.mankier.com/1/pycodestyle

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max_line_length = 120

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     tests_require=[
         'requests-mock>=1.0,<2.0',
         'pytest',
+        'pycodestyle',
         'mock'
     ]
 )


### PR DESCRIPTION
I hadn't realized this is where the 80 column limit was coming from. I put 120 without much thought - would also be ok with 100? Anyone have strong opinions?

Any other rules people would like added or turned off while we're thinking about it? This page seems to cover the options: https://www.mankier.com/1/pycodestyle