### PR TITLE
Jac/no cert check

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,6 @@
+
+Developer Readme
+
+
+- run tests: python setup.py test (yes, this is deprecated)
+- style is enforced with pycodestyle, mostly using default settings. https://www.mankier.com/1/pycodestyle

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max_line_length = 120

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     tests_require=[
         'requests-mock>=1.0,<2.0',
         'pytest',
+        'pycodestyle',
         'mock'
     ]
 )

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -72,7 +72,7 @@ class Session:
         return tableau_server
 
     def _create_server_connection(self, args):
-        self.logger.info("server: {}".format(self.server))
+        self._print_server_info()
         # args to handle here: proxy, --no-proxy, cert, --no-certcheck, timeout
         tableau_server = TSC.Server(self.server)
         if args.no_certcheck:
@@ -80,16 +80,29 @@ class Session:
         tableau_server.use_server_version()  # this will attempt to contact the server
         return tableau_server
 
+    def _print_server_info(self):
+
+        self.logger.info("===== Creating new session")
+        self.logger.info("===== Server: {}".format(self.server))
+        if self.username:
+            self.logger.info("===== Username: {}".format(self.username))
+        else:
+            self.logger.info("===== Token Name: {}".format(self.token_name))
+        self.logger.info("===== Site: {}".format(self.site))
+        self.logger.info("===== Connecting to the server...")
+
     def _reuse_session(self, args):
         try:
             tableau_server = self._create_server_connection(self, args)
-        except TSC.ServerResponseError as e:
+        except Exception as e:
+            self.logger.debug("Saved session token was invalid or something went wrong connecting to the server:")
+            self.logger.debug(e)
             self.auth_token = None
             return None
         tableau_server._auth_token = self.auth_token
         tableau_server._site_id = self.site_id
         # todo check current behavior: show this before or after successful login?
-        self.logger.info("==========Continuing previous session========")
+        self.logger.info("===== Continuing previous session")
         return tableau_server
 
     def create_session(self, args):

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -45,12 +45,12 @@ class Session:
         if self.server is None:
             self.logger.error("Please pass server")
             sys.exit()
-        if self.site is None:
+        if self.site is None: # they don't have to specify a site
             self.site = ''
 
     def _no_cookie_save_session_creation_with_username(self, args):
         try:
-            if self.password is None: # check for --no-prompt
+            if self.password is None and args.prompt == True:
                 self.password = getpass.getpass("Password:")
             self._check_for_missing_arguments()
             self.logger.info("server: {}".format(
@@ -74,7 +74,7 @@ class Session:
         self.logger.info("server: {}".format(
             self.server))
         try:
-            if self.token is None:  # check for --no-prompt
+            if self.token is None and args.prompt == True:
                 self.token = getpass.getpass("Token:")
             self._check_for_missing_arguments()
             tableau_auth = \
@@ -139,6 +139,8 @@ class Session:
 
     def _create_new_session_using_username(self, args):
         self._update_session_data(args)
+        # this seems to think it's getting a signed_in_object, but the method returns a TSC server object?
+        # also, what does the 'no_cookie' title mean here?
         signed_in_object \
             = self._no_cookie_save_session_creation_with_username(args)
         return signed_in_object

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -45,12 +45,12 @@ class Session:
         if self.server is None:
             self.logger.error("Please pass server")
             sys.exit()
-        if self.site is None: # they don't have to specify a site
+        if self.site is None:  # they don't have to specify a site
             self.site = ''
 
     def _no_cookie_save_session_creation_with_username(self, args):
         try:
-            if self.password is None and args.prompt == True:
+            if self.password is None and args.prompt is True:
                 self.password = getpass.getpass("Password:")
             self._check_for_missing_arguments()
             self.logger.info("server: {}".format(
@@ -69,12 +69,11 @@ class Session:
                 self.logger.error("Please Login again and check login "
                                   "credentials", e)
 
-
     def _no_cookie_save_session_creation_with_token(self, args):
         self.logger.info("server: {}".format(
             self.server))
         try:
-            if self.token is None and args.prompt == True:
+            if self.token is None and args.prompt is True:
                 self.token = getpass.getpass("Token:")
             self._check_for_missing_arguments()
             tableau_auth = \
@@ -97,7 +96,7 @@ class Session:
     def _create_server_connection(self, args):
         # args to handle here: proxy, --no-proxy, cert, --no-certcheck, timeout
         tableau_server = TSC.Server(self.server)
-        tableau_server.version = '3.16' # not sure what the ideal choice here is
+        tableau_server.version = '3.16'  # not sure what the ideal choice here is
         # can't just use server version because that doesn't work with no-certcheck
         if args.no_certcheck:
             tableau_server.add_http_options({'verify': False})
@@ -128,7 +127,6 @@ class Session:
             self.logger.error("Unable to find or create a session. Please check credentials and login again.")
             sys.exit()
 
-
         self.logger.info("==========Continuing previous session========")
         signed_in_object = self._reuse_session()
         if args.no_cookie:
@@ -151,7 +149,6 @@ class Session:
             = self._no_cookie_save_session_creation_with_token(args)
         return signed_in_object
 
-
     def _check_last_login_username_token_name(self):
         last_login_username_present = False
         last_login_token_name_present = False
@@ -172,14 +169,12 @@ class Session:
                 last_login_token_name_present, \
                 username, token_name
 
-
-### json file functions
+# json file functions
 
     def _get_file_path(self):
         home_path = os.path.expanduser("~")
         file_path = os.path.join(home_path, 'tableau_auth.json')
         return file_path
-
 
     def _read_from_json(self):
         if not self._check_json():
@@ -197,12 +192,10 @@ class Session:
                 self.token = auth['personal_access_token']
                 self.last_login_using = auth['last_login_using']
 
-
     def _check_json(self):
         home_path = os.path.expanduser("~")
         file_path = os.path.join(home_path, 'tableau_auth.json')
         return os.path.exists(file_path)
-
 
     def _save_token_to_json_file(self):
         data = {}
@@ -220,7 +213,6 @@ class Session:
         file_path = self._get_file_path()
         with open(str(file_path), 'w') as f:
             json.dump(data, f)
-
 
     def _remove_json(self):
         file_path = self._get_file_path()

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -23,37 +23,9 @@ class Session:
         self.last_login_using = None
         self.logging_level = "info"
         self.logger = log('tabcmd.session', self.logging_level)
-        self.read_from_json()
+        self._read_from_json()
 
-    def get_file_path(self):
-        home_path = os.path.expanduser("~")
-        file_path = os.path.join(home_path, 'tableau_auth.json')
-        return file_path
-
-    def read_json(self):
-        file_path = self.get_file_path()
-        with open(str(file_path), 'r') as input:
-            data = json.load(input)
-            for auth in data['tableau_auth']:
-                self.auth_token = auth['token']
-                self.server = auth['server']
-                self.site = auth['site_name']
-                self.site_id = auth['site_id']
-                self.username = auth['username']
-                self.token_name = auth['personal_access_token_name']
-                self.token = auth['personal_access_token']
-                self.last_login_using = auth['last_login_using']
-
-    def read_from_json(self):
-        if self.check_json():
-            self.read_json()
-
-    def check_json(self):
-        home_path = os.path.expanduser("~")
-        file_path = os.path.join(home_path, 'tableau_auth.json')
-        return os.path.exists(file_path)
-
-    def update_session(self, args):
+    def _update_session_data(self, args):
         if args.username:
             self.username = args.username
         if args.site is not None:
@@ -69,42 +41,23 @@ class Session:
         if args.token:
             self.token = args.token
 
-    def check_for_missing_arguments(self):
+    def _check_for_missing_arguments(self):
         if self.server is None:
             self.logger.error("Please pass server")
             sys.exit()
         if self.site is None:
-            self.logger.error("Please pass site")
-            sys.exit()
+            self.site = ''
 
-    def save_token_to_json_file(self):
-        data = {}
-        data['tableau_auth'] = []
-        data['tableau_auth'].append({
-            'token': self.auth_token,
-            'server': self.server,
-            'username': self.username,
-            'site_name': self.site,
-            'site_id': self.site_id,
-            'personal_access_token_name': self.token_name,
-            'personal_access_token': self.token,
-            'last_login_using': self.last_login_using
-        })
-        file_path = self.get_file_path()
-        with open(str(file_path), 'w') as f:
-            json.dump(data, f)
-
-    def no_cookie_save_session_creation_with_username(self):
+    def _no_cookie_save_session_creation_with_username(self, args):
         try:
-            if self.password is None:
+            if self.password is None: # check for --no-prompt
                 self.password = getpass.getpass("Password:")
-            self.check_for_missing_arguments()
+            self._check_for_missing_arguments()
             self.logger.info("server: {}".format(
                 self.server))
             tableau_auth = TSC.TableauAuth(self.username,
                                            self.password, self.site)
-            tableau_server = TSC.Server(self.server,
-                                        use_server_version=True)
+            tableau_server = self._create_server_connection(args)
             signed_in_object = tableau_server.auth.sign_in(tableau_auth)
             self.auth_token = tableau_server.auth_token
             self.site_id = tableau_server.site_id
@@ -116,25 +69,18 @@ class Session:
                 self.logger.error("Please Login again and check login "
                                   "credentials", e)
 
-    def reuse_session(self):
-        tableau_server = TSC.Server(self.server,
-                                    use_server_version=True)
-        tableau_server._auth_token = self.auth_token
-        tableau_server._site_id = self.site_id
-        return tableau_server
 
-    def no_cookie_save_session_creation_with_token(self):
+    def _no_cookie_save_session_creation_with_token(self, args):
         self.logger.info("server: {}".format(
             self.server))
         try:
-            if self.token is None:
+            if self.token is None:  # check for --no-prompt
                 self.token = getpass.getpass("Token:")
-            self.check_for_missing_arguments()
+            self._check_for_missing_arguments()
             tableau_auth = \
                 TSC.PersonalAccessTokenAuth(self.token_name,
                                             self.token, self.site)
-            tableau_server = \
-                TSC.Server(self.server, use_server_version=True)
+            tableau_server = self._create_server_connection(args)
             signed_in_object = \
                 tableau_server.auth.sign_in_with_personal_access_token(
                     tableau_auth)
@@ -148,40 +94,71 @@ class Session:
                 self.logger.error("Please Login again and check login "
                                   "credentials")
 
+    def _create_server_connection(self, args):
+        # args to handle here: proxy, --no-proxy, cert, --no-certcheck, timeout
+        tableau_server = TSC.Server(self.server)
+        tableau_server.version = '3.16' # not sure what the ideal choice here is
+        # can't just use server version because that doesn't work with no-certcheck
+        if args.no_certcheck:
+            tableau_server.add_http_options({'verify': False})
+        return tableau_server
+
+    def _reuse_session(self):
+        tableau_server = TSC.Server(self.server,
+                                    use_server_version=True)
+        tableau_server._auth_token = self.auth_token
+        tableau_server._site_id = self.site_id
+        return tableau_server
+
     def create_session(self, args):
         signed_in_object = None
         if args.username or args.password:
-            signed_in_object = self.create_new_session_using_username(args)
+            signed_in_object = self._create_new_session_using_username(args)
         elif args.token or args.token_name:
-            signed_in_object = self.create_new_session_using_token(args)
+            signed_in_object = self._create_new_session_using_token(args)
         elif args.site or args.server:
             last_login_username_present, last_login_token_name_present, \
                 username, token_name = \
-                self.check_last_login_username_token_name()
+                self._check_last_login_username_token_name()
             if last_login_username_present:
-                signed_in_object = self.create_new_session_using_username(args)
+                signed_in_object = self._create_new_session_using_username(args)
             elif last_login_token_name_present:
-                signed_in_object = self.create_new_session_using_token(args)
+                signed_in_object = self._create_new_session_using_token(args)
         else:
-            self.logger.info("==========Continuing previous session========")
-            signed_in_object = self.reuse_session()
+            self.logger.error("Unable to find or create a session. Please check credentials and login again.")
+            sys.exit()
+
+
+        self.logger.info("==========Continuing previous session========")
+        signed_in_object = self._reuse_session()
         if args.no_cookie:
-            self.remove_json()
+            self._remove_json()
         else:
-            self.save_token_to_json_file()
+            self._save_token_to_json_file()
         return signed_in_object
 
-    def remove_json(self):
-        file_path = self.get_file_path()
-        if os.path.exists(file_path):
-            os.remove(file_path)
+    def _create_new_session_using_username(self, args):
+        self._update_session_data(args)
+        signed_in_object \
+            = self._no_cookie_save_session_creation_with_username(args)
+        return signed_in_object
 
-    def check_last_login_username_token_name(self):
+    def _create_new_session_using_token(self, args):
+        self._update_session_data(args)
+        signed_in_object \
+            = self._no_cookie_save_session_creation_with_token(args)
+        return signed_in_object
+
+
+    def _check_last_login_username_token_name(self):
         last_login_username_present = False
         last_login_token_name_present = False
         username = False
         token_name = False
-        file_path = self.get_file_path()
+        if not self._check_json():
+            return
+        # TODO can this call read_from_json instead of opening the file itself?
+        file_path = self._get_file_path()
         with open(str(file_path), 'r') as input:
             data = json.load(input)
             for auth in data['tableau_auth']:
@@ -193,14 +170,57 @@ class Session:
                 last_login_token_name_present, \
                 username, token_name
 
-    def create_new_session_using_username(self, args):
-        self.update_session(args)
-        signed_in_object \
-            = self.no_cookie_save_session_creation_with_username()
-        return signed_in_object
 
-    def create_new_session_using_token(self, args):
-        self.update_session(args)
-        signed_in_object \
-            = self.no_cookie_save_session_creation_with_token()
-        return signed_in_object
+### json file functions
+
+    def _get_file_path(self):
+        home_path = os.path.expanduser("~")
+        file_path = os.path.join(home_path, 'tableau_auth.json')
+        return file_path
+
+
+    def _read_from_json(self):
+        if not self._check_json():
+            return
+        file_path = self._get_file_path()
+        with open(str(file_path), 'r') as input:
+            data = json.load(input)
+            for auth in data['tableau_auth']:
+                self.auth_token = auth['token']
+                self.server = auth['server']
+                self.site = auth['site_name']
+                self.site_id = auth['site_id']
+                self.username = auth['username']
+                self.token_name = auth['personal_access_token_name']
+                self.token = auth['personal_access_token']
+                self.last_login_using = auth['last_login_using']
+
+
+    def _check_json(self):
+        home_path = os.path.expanduser("~")
+        file_path = os.path.join(home_path, 'tableau_auth.json')
+        return os.path.exists(file_path)
+
+
+    def _save_token_to_json_file(self):
+        data = {}
+        data['tableau_auth'] = []
+        data['tableau_auth'].append({
+            'token': self.auth_token,
+            'server': self.server,
+            'username': self.username,
+            'site_name': self.site,
+            'site_id': self.site_id,
+            'personal_access_token_name': self.token_name,
+            'personal_access_token': self.token,
+            'last_login_using': self.last_login_using
+        })
+        file_path = self._get_file_path()
+        with open(str(file_path), 'w') as f:
+            json.dump(data, f)
+
+
+    def _remove_json(self):
+        file_path = self._get_file_path()
+        if os.path.exists(file_path):
+            os.remove(file_path)

--- a/tabcmd/parsers/parent_parser.py
+++ b/tabcmd/parsers/parent_parser.py
@@ -62,7 +62,7 @@ class ParentParser:
         proxy_group = parser.add_mutually_exclusive_group()
         proxy_group.add_argument('--no-proxy', action='store_false', dest='proxy',
                help='When specified, an HTTP proxy will not be used.')
-        proxy_group.add_argument('--proxy', '-x', action='store_true', dest='proxy', metavar='Host:Port',
+        proxy_group.add_argument('--proxy', '-x', dest='proxy', metavar='Host:Port',
                help='Connect to Tableau Server using the specified HTTP proxy.')
 
         parser.add_argument('--use-certificate', '-c',

--- a/tabcmd/parsers/parent_parser.py
+++ b/tabcmd/parsers/parent_parser.py
@@ -42,4 +42,6 @@ class ParentParser:
                            help='do not save session id')
         group.add_argument('--cookie', action='store_true',
                            help='save session id')
+        parser.add_argument('--no-certcheck', action='store_true',
+               help='When specified, tabcmd (the client) does not validate the server\'s SSL certificate.')
         return parser

--- a/tabcmd/parsers/parent_parser.py
+++ b/tabcmd/parsers/parent_parser.py
@@ -8,69 +8,70 @@ class ParentParser:
     """Parser that will be inherited by all commands. Contains
     authentication and logging level setting"""
 
+     # ordered alphabetically by short option - this is reflected directly in help output
     def parent_parser_with_global_options(self):
         parser = argparse.ArgumentParser(usage=argparse.SUPPRESS,
                                          add_help=False)
-        parser.add_argument('--server', '-s', metavar='',
-               help='Use the specified Tableau Server URL. If no protocol is specified, http:// is assumed')
 
-        credential_group = parser.add_mutually_exclusive_group()
-        credential_group.add_argument('--username', '-u', metavar='',
-               help='The Tableau Server username. If using a password to sign in, this is required\
-                     at least once to begin session.')
-        credential_group.add_argument('--token-name', '-tn', metavar='',
-               help='The name of the Tableau Server Personal Access Token. If using a token to sign in,\
-                     this is required at least once to begin session.')
-
-        password_group = parser.add_mutually_exclusive_group()
-        password_group.add_argument('--password-file',
-               help='Allows the password to be stored in the given .txt file rather than the command \
-                    line for increased security.') # TODO: not yet implemented? Should it work for a token too?
-        password_group.add_argument('--password', '-p', metavar='',
-                            help='The Tableau Server password, which is required at least once to begin session.')
-        password_group.add_argument('--token', '-to', default=None, metavar='',
-                            help='personal access token to sign into the server')
-
-        parser.add_argument('--site', '-t', default='', metavar='',
-               help='Use the specified Tableau Server site. Specify an empty string ("") to force use of\
-                                 the default site')
-
-        prompt_group = parser.add_mutually_exclusive_group()
-        # the variable args.prompt will be set to false if --no-prompt is present
-        prompt_group.add_argument('--no-prompt', action='store_false', dest='prompt',
-                                  help='no prompt for password')
-        prompt_group.add_argument('--prompt', action='store_true', dest='prompt',
-                                  help='prompt for password')
-
-        parser.add_argument('--logging-level', '-l',
-                            choices=['debug', 'info', 'error'],
-                            default='info',
-                            help='desired logging level (set to info by default)')
-
-        group = parser.add_mutually_exclusive_group()
-        # the variable args.no_cookie will be set to true if --no-cookie is present, false for --cookie
-        group.add_argument('--no-cookie', action='store_true', dest='no_cookie',
-                           help='Do not save the session ID when signing in. Subsequent commands will need \
-                                to sign in again.')
-        group.add_argument('--cookie', action='store_false', dest='no_cookie',
-                           help='Save the session ID when signing in. Subsequent commands will not need to \
-                                sign in again. If unspecified, this is the default behavior')
+        # The default behavior is to try certificates in the computer store, like a browser?
+        # There is no option to say 'use defaults'
+        # NOT YET IMPLEMENTED
+        parser.add_argument('-c', '--use-certificate', metavar='',
+               help='Use client certificate to sign in. Required when mutual SSL is enabled.')
+        # NOT YET IMPLEMENTED
+        parser.add_argument('-h', '--help', metavar='', help="Display tabcmd help and exit.")
+        parser.add_argument('-l', '--logging-level', choices=['DEBUG', 'INFO', 'ERROR'], default='info', metavar='',
+               help='Use the specified logging level. If not specified, the default level is INFO.')
 
         parser.add_argument('--no-certcheck', action='store_true',
                help='When specified, tabcmd (the client) does not validate the server\'s SSL certificate.')
 
+        parser.add_argument('--no-prompt', action='store_true', help='no prompt for password')
+
+        cookies = parser.add_mutually_exclusive_group()
+        cookies.add_argument('--no-cookie', action='store_true',
+               help='Do not save the session ID when signing in. Subsequent commands will need to sign in again.')
+        cookies.add_argument('-o', '--cookie', action='store_true',
+               help='Save the session ID when signing in. Subsequent commands will NOT need \
+                                to sign in again. This is the default behavior.')
+
+        auth_options = parser.add_mutually_exclusive_group()
+        auth_options.add_argument('-n', '--token-name', metavar='<TOKEN NAME>',
+               help='The name of the Tableau Server Personal Access Token. If using a token to sign in,\
+                     this is required at least once to begin session.')
+        parser.add_argument('-k', '--token', default=None, metavar='<TOKEN VALUE>',
+               help='Use the specified Tableau Server Personal Access Token. Requires --token-name to be set.')
+        parser.add_argument('-p', '--password', metavar='<PASSWORD>',
+               help='Use the specified Tableau Server password. Requires --username to be set.')
+
+        # NOT YET IMPLEMENTED
+        parser.add_argument('--password-file', metavar='<FILE>',
+               help='Allows the password to be stored in the given .txt file rather than the command \
+                    line for increased security.') # TODO: not yet implemented? Should it work for a token too?
+
+        # NOT YET IMPLEMENTED
         proxy_group = parser.add_mutually_exclusive_group()
-        proxy_group.add_argument('--no-proxy', action='store_false', dest='proxy',
-               help='When specified, an HTTP proxy will not be used.')
-        proxy_group.add_argument('--proxy', '-x', dest='proxy', metavar='Host:Port',
+        proxy_group.add_argument('--proxy', dest='proxy', metavar='<HOST:PORT>',
                help='Connect to Tableau Server using the specified HTTP proxy.')
+        proxy_group.add_argument('--no-proxy', action='store_false', dest='proxy',
+               help='Do not use a HTTP proxy.') # is this the default behavior?
 
-        parser.add_argument('--use-certificate', '-c',
-               help='Use client certificate to sign in. Required when mutual SSL is enabled.')
-        parser.add_argument('--timeout', # can't use -t, is already used for --site
-               help='Waits the specified number of seconds for the server to complete processing the \
-                    command. By default, the process will wait until the server responds.')
+        parser.add_argument('-s', '--server', metavar='<URL>',
+               help='Use the specified Tableau Server URL. If no protocol is specified, http:// is assumed.')
+        parser.add_argument('-t', '--site', default='', metavar='SITEID',
+               help='Use the specified Tableau Server site. Leave empty or specify an empty string ("") to \
+                    force use of the default site')
 
-        parser.add_argument('--version', '-v', action='version', version="%(prog)s (v2.pre-release)")
+        # NOT YET IMPLEMENTED
+        parser.add_argument('--timeout', metavar='<SECONDS>', # can't use -t, it's already used for --site
+               help='How long to wait, in seconds, for the server to complete processing the command. The default \
+                    behavior is to wait until the server responds.')
+
+        auth_options.add_argument('-u', '--username', metavar='<USER>',
+                help='Use the specified Tableau Server username. For Tableau Online, this will be an email address.')
+
+        parser.add_argument('-v', '--version', action='version', version="%(prog)s (v2.pre-release)",
+               help='Show version information and exit.')
+
 
         return parser

--- a/tabcmd/parsers/parent_parser.py
+++ b/tabcmd/parsers/parent_parser.py
@@ -12,36 +12,66 @@ class ParentParser:
         parser = argparse.ArgumentParser(usage=argparse.SUPPRESS,
                                          add_help=False)
         parser.add_argument('--server', '-s', metavar='',
-                            help='server of account holder')
-        parser.add_argument('--username', '-u', metavar='',
-                            help='username of account holder')
-        parser.add_argument('--site', '-t', default=None, metavar='',
-                            help='Used in the URL to uniquely identify the '
-                                 'site.')
-        parser.add_argument('--password', '-p', metavar='',
-                            help='password of account holder')
+               help='The Tableau Server URL, which is required at least once to begin session.')
+
+        credential_group = parser.add_mutually_exclusive_group()
+        credential_group.add_argument('--username', '-u', metavar='',
+               help='The Tableau Server username. If using a password to sign in, this is required\
+                     at least once to begin session.')
+        credential_group.add_argument('--token-name', '-tn', metavar='',
+               help='The name of the Tableau Server Personal Access Token. If using a token to sign in,\
+                     this is required at least once to begin session.')
+
+        password_group = parser.add_mutually_exclusive_group()
+        password_group.add_argument('--password-file',
+               help='Allows the password to be stored in the given .txt file rather than the command \
+                    line for increased security.') # TODO: not yet implemented? Should it work for a token too?
+        password_group.add_argument('--password', '-p', metavar='',
+                            help='The Tableau Server password, which is required at least once to begin session.')
+        password_group.add_argument('--token', '-to', default=None, metavar='',
+                            help='personal access token to sign into the server')
+
+        parser.add_argument('--site', '-t', default='', metavar='',
+               help='Indicates that the command applies to the site specified by the Tableau Server site\
+                     ID, surrounded by single quotes or double quotes. To specify the Default site, \
+                          leave this blank.')
+
         prompt_group = parser.add_mutually_exclusive_group()
-        prompt_group.add_argument('--no-prompt', action='store_true',
+        # the variable args.prompt will be set to false if --no-prompt is present
+        prompt_group.add_argument('--no-prompt', action='store_false', dest='prompt',
                                   help='no prompt for password')
-        prompt_group.add_argument('--prompt', action='store_true',
+        prompt_group.add_argument('--prompt', action='store_true', dest='prompt',
                                   help='prompt for password')
+
         parser.add_argument('--logging-level', '-l',
                             choices=['debug', 'info', 'error'],
                             default='info',
-                            help='desired logging level '
-                                 '(set to error by default)')
-        parser.add_argument('--token', '-to', default=None, metavar='',
-                            help='personal access token to '
-                                 'sign into the '
-                                 'server')
-        parser.add_argument('--token-name', '-tn', metavar='',
-                            help='name of the personal access '
-                                 'token used to sign into the server')
+                            help='desired logging level (set to info by default)')
+
         group = parser.add_mutually_exclusive_group()
-        group.add_argument('--no-cookie', action='store_true',
-                           help='do not save session id')
-        group.add_argument('--cookie', action='store_true',
-                           help='save session id')
+        # the variable args.no_cookie will be set to true if --no-cookie is present, false for --cookie
+        group.add_argument('--no-cookie', action='store_true', dest='no_cookie',
+                           help='Do not save the session ID when signing in. Subsequent commands will need \
+                                to sign in again.')
+        group.add_argument('--cookie', action='store_false', dest='no_cookie',
+                           help='Save the session ID when signing in. Subsequent commands will not need to \
+                                sign in again. If unspecified, this is the default behavior')
+
         parser.add_argument('--no-certcheck', action='store_true',
                help='When specified, tabcmd (the client) does not validate the server\'s SSL certificate.')
+
+        proxy_group = parser.add_mutually_exclusive_group()
+        proxy_group.add_argument('--no-proxy', action='store_false', dest='proxy',
+               help='When specified, an HTTP proxy will not be used.')
+        proxy_group.add_argument('--proxy', '-x', action='store_true', dest='proxy', metavar='Host:Port',
+               help='Connect to Tableau Server using the specified HTTP proxy.')
+
+        parser.add_argument('--use-certificate', '-c',
+               help='Use client certificate to sign in. Required when mutual SSL is enabled.')
+        parser.add_argument('--timeout', # can't use -t, is already used for --site
+               help='Waits the specified number of seconds for the server to complete processing the \
+                    command. By default, the process will wait until the server responds.')
+
+        parser.add_argument('--version', '-v', action='version', version="%(prog)s (v2.pre-release)")
+
         return parser

--- a/tabcmd/parsers/parent_parser.py
+++ b/tabcmd/parsers/parent_parser.py
@@ -1,77 +1,88 @@
 import argparse
-import sys
-import textwrap
-from .help_parser import HelpParser
 
 
 class ParentParser:
     """Parser that will be inherited by all commands. Contains
     authentication and logging level setting"""
 
-     # ordered alphabetically by short option - this is reflected directly in help output
+    # ordered alphabetically by short option - this is reflected directly in help output
     def parent_parser_with_global_options(self):
-        parser = argparse.ArgumentParser(usage=argparse.SUPPRESS,
-                                         add_help=False)
+        parser = argparse.ArgumentParser(usage=argparse.SUPPRESS, add_help=False)
 
         # The default behavior is to try certificates in the computer store, like a browser?
         # There is no option to say 'use defaults'
         # NOT YET IMPLEMENTED
-        parser.add_argument('-c', '--use-certificate', metavar='',
-               help='Use client certificate to sign in. Required when mutual SSL is enabled.')
-        # NOT YET IMPLEMENTED
-        parser.add_argument('-h', '--help', metavar='', help="Display tabcmd help and exit.")
-        parser.add_argument('-l', '--logging-level', choices=['DEBUG', 'INFO', 'ERROR'], default='info', metavar='',
-               help='Use the specified logging level. If not specified, the default level is INFO.')
-
-        parser.add_argument('--no-certcheck', action='store_true',
-               help='When specified, tabcmd (the client) does not validate the server\'s SSL certificate.')
-
-        parser.add_argument('--no-prompt', action='store_true', help='no prompt for password')
-
+        parser.add_argument(
+             '-c', '--use-certificate', metavar='',
+             help='Use client certificate to sign in. Required when mutual SSL is enabled.')
         cookies = parser.add_mutually_exclusive_group()
-        cookies.add_argument('--no-cookie', action='store_true',
-               help='Do not save the session ID when signing in. Subsequent commands will need to sign in again.')
-        cookies.add_argument('-o', '--cookie', action='store_true',
-               help='Save the session ID when signing in. Subsequent commands will NOT need \
-                                to sign in again. This is the default behavior.')
+        cookies.add_argument(
+             '--cookie', action='store_true',
+             help='Save the session ID when signing in. Subsequent commands will NOT need \
+                   to sign in again. This is the default behavior.')
+        # NOT YET IMPLEMENTED parser.add_argument('-h', '--help', metavar='', help="Display tabcmd help and exit.")
+        parser.add_argument(
+             '-l', '--logging-level', choices=['DEBUG', 'INFO', 'ERROR'], default='info', metavar='',
+             help='Use the specified logging level. If not specified, the default level is INFO.')
+
+        parser.add_argument(
+             '--no-certcheck', action='store_true',
+             help='When specified, tabcmd (the client) does not validate the server\'s SSL certificate.')
+
+        parser.add_argument(
+             '--no-prompt', action='store_true', help='no prompt for password')
+
+        cookies.add_argument(
+             '--no-cookie', action='store_true',
+             help='Do not save the session ID when signing in. Subsequent commands will need to sign in again.')
 
         auth_options = parser.add_mutually_exclusive_group()
-        auth_options.add_argument('-n', '--token-name', metavar='<TOKEN NAME>',
-               help='The name of the Tableau Server Personal Access Token. If using a token to sign in,\
-                     this is required at least once to begin session.')
-        parser.add_argument('-k', '--token', default=None, metavar='<TOKEN VALUE>',
-               help='Use the specified Tableau Server Personal Access Token. Requires --token-name to be set.')
-        parser.add_argument('-p', '--password', metavar='<PASSWORD>',
-               help='Use the specified Tableau Server password. Requires --username to be set.')
+        auth_options.add_argument(
+             '-tn', '--token-name', metavar='<TOKEN NAME>',
+             help='The name of the Tableau Server Personal Access Token. If using a token to sign in,\
+                  this is required at least once to begin session.')
+        parser.add_argument(
+             '-to', '--token', default=None, metavar='<TOKEN VALUE>',
+             help='Use the specified Tableau Server Personal Access Token. Requires --token-name to be set.')
+        parser.add_argument(
+             '-p', '--password', metavar='<PASSWORD>',
+             help='Use the specified Tableau Server password. Requires --username to be set.')
 
         # NOT YET IMPLEMENTED
-        parser.add_argument('--password-file', metavar='<FILE>',
-               help='Allows the password to be stored in the given .txt file rather than the command \
-                    line for increased security.') # TODO: not yet implemented? Should it work for a token too?
+        parser.add_argument(
+             '--password-file', metavar='<FILE>',
+             help='Allows the password to be stored in the given .txt file rather than the command \
+                    line for increased security.')  # TODO: not yet implemented? Should it work for a token too?
 
         # NOT YET IMPLEMENTED
         proxy_group = parser.add_mutually_exclusive_group()
-        proxy_group.add_argument('--proxy', dest='proxy', metavar='<HOST:PORT>',
-               help='Connect to Tableau Server using the specified HTTP proxy.')
-        proxy_group.add_argument('--no-proxy', action='store_false', dest='proxy',
-               help='Do not use a HTTP proxy.') # is this the default behavior?
+        proxy_group.add_argument(
+             '--proxy', dest='proxy', metavar='<HOST:PORT>',
+             help='Connect to Tableau Server using the specified HTTP proxy.')
+        proxy_group.add_argument(
+             '--no-proxy', action='store_false', dest='proxy',
+             help='Do not use a HTTP proxy.')  # is this the default behavior?
 
-        parser.add_argument('-s', '--server', metavar='<URL>',
-               help='Use the specified Tableau Server URL. If no protocol is specified, http:// is assumed.')
-        parser.add_argument('-t', '--site', default='', metavar='SITEID',
-               help='Use the specified Tableau Server site. Leave empty or specify an empty string ("") to \
+        parser.add_argument(
+             '-s', '--server', metavar='<URL>',
+             help='Use the specified Tableau Server URL. If no protocol is specified, http:// is assumed.')
+        parser.add_argument(
+             '-t', '--site', default='', metavar='SITEID',
+             help='Use the specified Tableau Server site. Leave empty or specify an empty string ("") to \
                     force use of the default site')
 
         # NOT YET IMPLEMENTED
-        parser.add_argument('--timeout', metavar='<SECONDS>', # can't use -t, it's already used for --site
-               help='How long to wait, in seconds, for the server to complete processing the command. The default \
+        parser.add_argument(
+             '--timeout', metavar='<SECONDS>',  # can't use -t, it's already used for --site
+             help='How long to wait, in seconds, for the server to complete processing the command. The default \
                     behavior is to wait until the server responds.')
 
-        auth_options.add_argument('-u', '--username', metavar='<USER>',
-                help='Use the specified Tableau Server username. For Tableau Online, this will be an email address.')
+        auth_options.add_argument(
+             '-u', '--username', metavar='<USER>',
+             help='Use the specified Tableau Server username. For Tableau Online, this will be an email address.')
 
-        parser.add_argument('-v', '--version', action='version', version="%(prog)s (v2.pre-release)",
-               help='Show version information and exit.')
-
+        parser.add_argument(
+             '-v', '--version', action='version', version="%(prog)s (v2.pre-release)",
+             help='Show version information and exit.')
 
         return parser

--- a/tabcmd/parsers/parent_parser.py
+++ b/tabcmd/parsers/parent_parser.py
@@ -12,7 +12,7 @@ class ParentParser:
         parser = argparse.ArgumentParser(usage=argparse.SUPPRESS,
                                          add_help=False)
         parser.add_argument('--server', '-s', metavar='',
-               help='The Tableau Server URL, which is required at least once to begin session.')
+               help='Use the specified Tableau Server URL. If no protocol is specified, http:// is assumed')
 
         credential_group = parser.add_mutually_exclusive_group()
         credential_group.add_argument('--username', '-u', metavar='',
@@ -32,9 +32,8 @@ class ParentParser:
                             help='personal access token to sign into the server')
 
         parser.add_argument('--site', '-t', default='', metavar='',
-               help='Indicates that the command applies to the site specified by the Tableau Server site\
-                     ID, surrounded by single quotes or double quotes. To specify the Default site, \
-                          leave this blank.')
+               help='Use the specified Tableau Server site. Specify an empty string ("") to force use of\
+                                 the default site')
 
         prompt_group = parser.add_mutually_exclusive_group()
         # the variable args.prompt will be set to false if --no-prompt is present


### PR DESCRIPTION
1. Implemented --no-cert-check so I could run against all our internal servers :) 
2. implemented --no-prompt while I was in Session.py
3. Also added remaining global options to the parser, alphabetized them and updated help text, taking it from existing tabcmd. 
4. did a bunch of moving around in session.py: methods only used within the file now start with _, and I tried to move all the file-handling methods to the bottom. 

help output:
![image](https://user-images.githubusercontent.com/2009720/152916060-19e57f93-14e0-4ff3-a163-de54f6864210.png)
