### PR TITLE
Fixed Command bugs: CreateGroup, DeleteGroup, DeleteProject, Delete

### DIFF
--- a/tabcmd/commands/group/create_group_command.py
+++ b/tabcmd/commands/group/create_group_command.py
@@ -23,7 +23,7 @@ class CreateGroupCommand(GroupCommand):
         server = session.create_session(args)
         """Method to create group using Tableauserverclient methods"""
         try:
-            new_group = TSC.GroupItem(args.group_name)
+            new_group = TSC.GroupItem(args.name)
             server.groups.create(new_group)
             logger.info("Successfully created group")
         except TSC.ServerResponseError as e:

--- a/tabcmd/commands/group/delete_group_command.py
+++ b/tabcmd/commands/group/delete_group_command.py
@@ -22,7 +22,7 @@ class DeleteGroupCommand(GroupCommand):
         session = Session()
         server = session.create_session(args)
         try:
-            group_id = GroupCommand.find_group_id(server, args.group_name)
+            group_id = GroupCommand.find_group_id(server, args.groupname)
             server.groups.delete(group_id)
             logger.info("Successfully deleted group")
         except TSC.ServerResponseError as e:

--- a/tabcmd/commands/project/create_project_command.py
+++ b/tabcmd/commands/project/create_project_command.py
@@ -21,12 +21,12 @@ class CreateProjectCommand(ProjectCommand):
         logger.debug("Launching command")
         session = Session()
         server = session.create_session(args)
-        if args.parent_path_name is not None:
-            project_path = ProjectCommand.find_project_id(server, args.parent_path_name)
+        if args.parent_project_path is not None:
+            project_path = ProjectCommand.find_project_id(server, args.parent_project_path)
         else:
             project_path = None
 
-        top_level_project = TSC.ProjectItem(args.project_name, args.description, args.content_permission,
+        top_level_project = TSC.ProjectItem(args.name, args.description, None,
                                             project_path)
         try:
             project_item = server.projects.create(top_level_project)

--- a/tabcmd/parsers/create_group_parser.py
+++ b/tabcmd/parsers/create_group_parser.py
@@ -10,4 +10,4 @@ class CreateGroupParser:
     def create_group_parser(manager, command):
         """Method to parse create group arguments passed by the user"""
         create_group_parser = manager.include(command)
-        create_group_parser.add_argument('groupname')
+        create_group_parser.add_argument('name')

--- a/tabcmd/parsers/delete_parser.py
+++ b/tabcmd/parsers/delete_parser.py
@@ -9,7 +9,8 @@ class DeleteParser:
         """Method to parse delete data source arguments passed by the user"""
 
         delete_parser = manager.include(command)
-        delete_parser.add_argument('name', nargs='?', help='The datasource or workbook to delete')
-        delete_parser.add_argument('--workbook', required=False, help='The workbook to delete')
-        delete_parser.add_argument('--datasource', required=False, help='The datasource to delete')
+        delete_parser_group = delete_parser.add_mutually_exclusive_group(required=True)
+        delete_parser_group.add_argument('name', nargs='?', help='The datasource or workbook to delete')
+        delete_parser_group.add_argument('--workbook', required=False, help='The workbook to delete')
+        delete_parser_group.add_argument('--datasource', required=False, help='The datasource to delete')
         set_project_r_arg(delete_parser)

--- a/tabcmd/parsers/delete_parser.py
+++ b/tabcmd/parsers/delete_parser.py
@@ -9,5 +9,7 @@ class DeleteParser:
         """Method to parse delete data source arguments passed by the user"""
 
         delete_parser = manager.include(command)
-        delete_parser.add_argument('name', help='The datasource or workbook to delete')
+        delete_parser.add_argument('name', nargs='?', help='The datasource or workbook to delete')
+        delete_parser.add_argument('--workbook', required=False, help='The workbook to delete')
+        delete_parser.add_argument('--datasource', required=False, help='The datasource to delete')
         set_project_r_arg(delete_parser)

--- a/tabcmd/parsers/delete_project_parser.py
+++ b/tabcmd/parsers/delete_project_parser.py
@@ -10,5 +10,5 @@ class DeleteProjectParser:
     def delete_project_parser(manager, command):
         """Method to parse delete project arguments passed by the user"""
         delete_project_parser = manager.include(command)
-        delete_project_parser.add_argument('projectname', help='name of project to delete')
+        delete_project_parser.add_argument('name', help='name of project to delete')
         set_parent_project_arg(delete_project_parser)

--- a/tests/commands/test_run_commands.py
+++ b/tests/commands/test_run_commands.py
@@ -156,13 +156,14 @@ class RunCommandsTest(unittest.TestCase):
     # groups
     def test_create_group(self, mock_session, mock_server):
         mock_session.return_value = mock_server
-        mock_args.group_name = 'name'
+        mock_args.name = 'name'
         mock_session.assert_not_called()
         create_group_command.CreateGroupCommand.run_command(mock_args)
         mock_session.assert_called()
 
     def test_delete_group(self, mock_session, mock_server):
         mock_session.return_value = mock_server
+        mock_args.groupname = 'name'
         mock_server.groups = getter
         mock_session.assert_not_called()
         delete_group_command.DeleteGroupCommand.run_command(mock_args)
@@ -179,10 +180,10 @@ class RunCommandsTest(unittest.TestCase):
     def test_create_project(self, mock_session, mock_server):
         mock_session.return_value = mock_server
         mock_server.projects = getter
-        mock_args.project_name = 'name'
+        mock_args.name = 'name'
         mock_args.description = ''
         mock_args.content_permission = None
-        mock_args.parent_path_name = 'projects'
+        mock_args.parent_project_path = 'projects'
         mock_session.assert_not_called()
         create_project_command.CreateProjectCommand.run_command(mock_args)
         mock_session.assert_called()

--- a/tests/commands/test_run_commands.py
+++ b/tests/commands/test_run_commands.py
@@ -57,7 +57,9 @@ class RunCommandsTest(unittest.TestCase):
     def test_delete(self, mock_session, mock_server):
         mock_session.return_value = mock_server
         mock_server.workbooks = getter
+        mock_server.datasources = getter
         mock_args.workbook = True
+        mock_args.datasource = False
         mock_session.assert_not_called()
         with self.assertRaises(SystemExit):
             delete_command.DeleteCommand.run_command(mock_args)

--- a/tests/test_parser_create_group.py
+++ b/tests/test_parser_create_group.py
@@ -14,9 +14,9 @@ class CreateGroupParserTest(unittest.TestCase):
         CreateGroupParser.create_group_parser(manager, mock_command)
 
     def test_creategroup_parser_required_name(self):
-        mock_args = [commandname, 'groupname']
+        mock_args = [commandname, 'name']
         args = self.parser_under_test.parse_args(mock_args)
-        assert args.groupname == 'groupname'
+        assert args.name == 'name'
 
     def test_creategroup_parser_missing_all_args(self):
         mock_args = [commandname]

--- a/tests/test_parser_delete.py
+++ b/tests/test_parser_delete.py
@@ -19,14 +19,10 @@ class DeleteParserTestT(unittest.TestCase):
         cls.parser_under_test, manager, mock_command = initialize_test_pieces(commandname)
         DeleteParser.delete_parser(manager, mock_command)
 
-    def test_delete_parser_no_object(self):
-        mock_args = [commandname]
-        with self.assertRaises(SystemExit):
-            args = self.parser_under_test.parse_args(mock_args)
-
     def test_delete_parser(self):
         mock_args = [commandname, 'ds', '-r', 'proj']
         args = self.parser_under_test.parse_args(mock_args)
+        print(args)
         assert args.name == 'ds', args
         assert args.projectname == 'proj', args
 

--- a/tests/test_parser_delete.py
+++ b/tests/test_parser_delete.py
@@ -19,10 +19,14 @@ class DeleteParserTestT(unittest.TestCase):
         cls.parser_under_test, manager, mock_command = initialize_test_pieces(commandname)
         DeleteParser.delete_parser(manager, mock_command)
 
+    def test_delete_parser_no_object(self):
+        mock_args = [commandname]
+        with self.assertRaises(SystemExit):
+            args = self.parser_under_test.parse_args(mock_args)
+
     def test_delete_parser(self):
         mock_args = [commandname, 'ds', '-r', 'proj']
         args = self.parser_under_test.parse_args(mock_args)
-        print(args)
         assert args.name == 'ds', args
         assert args.projectname == 'proj', args
 


### PR DESCRIPTION
1. Deletegroup: https://github.com/tableau/tabcmd/issues/24

- Tabcmd2 "delete group" command contains flag --name as group name. To delete a group Tabcmd2 uses `tabcmd deletegroup --name "ExampleGroup"`. Original Tabcmd does not use --name flag. Updated the command code accordingly.

2. Deleteproject: https://github.com/tableau/tabcmd/issues/26

- Tabcmd2 "deleteproject" command contains flag --name as project name. To delete a project Tabcmd2 uses tabcmd depeteproject --name "ExampleProject". Tabcmd does not use --name flag. Updated the command code accordingly.

3.  Delete: https://github.com/tableau/tabcmd/issues/49

- Tabcmd2 requires user to specify workbook using flag —workbook for deleting a workbook where as in the existing Tabcmd user can either use —workbook flag OR send name of workbook as it is like this → `tabcmd delete "Sales_Analysis" ` without the flag. Updated the command code accordingly.