### PR TITLE
PEP338 Support - Execute Module as Script

### DIFF
--- a/tabcmd/__main__.py
+++ b/tabcmd/__main__.py
@@ -1,0 +1,5 @@
+from .tabcmd import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This makes it so you can just run `python -m tabcmd` and get the CLI to work. I *think* that should make the instructions for local development a lot easier to understand. 

Its also often a better end user experience to qualify the tabcmd calls with the python executable; if users have multiple Pythons installed on their system it makes it more explicit which one is actually invoicing tabcmd