### PR TITLE
Mock Import Cleanup

### DIFF
--- a/tests/commands/test_run_commands.py
+++ b/tests/commands/test_run_commands.py
@@ -2,8 +2,6 @@ import argparse
 import unittest
 from unittest.mock import *
 
-import mock
-
 from tabcmd.commands.auth import login_command, logout_command
 from tabcmd.commands.datasources_and_workbooks import (
     delete_command,

--- a/tests/test_logout_parser.py
+++ b/tests/test_logout_parser.py
@@ -1,9 +1,6 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 import argparse
 from tabcmd.parsers.logout_parser import LogoutParser
 from .common_setup import *

--- a/tests/test_parser_create_extracts.py
+++ b/tests/test_parser_create_extracts.py
@@ -1,6 +1,5 @@
 import unittest
 import sys
-from unittest import mock
 import argparse
 from tabcmd.parsers.create_extracts_parser import CreateExtractsParser
 from .common_setup import *

--- a/tests/test_parser_create_group.py
+++ b/tests/test_parser_create_group.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest import mock
 from tabcmd.parsers.create_group_parser import CreateGroupParser
 from .common_setup import *
 

--- a/tests/test_parser_create_project.py
+++ b/tests/test_parser_create_project.py
@@ -1,9 +1,5 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.create_project_parser import CreateProjectParser
 from .common_setup import *

--- a/tests/test_parser_create_site_users.py
+++ b/tests/test_parser_create_site_users.py
@@ -1,10 +1,7 @@
 import sys
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 import argparse
 from tabcmd.parsers.create_site_users_parser import CreateSiteUsersParser
 from .common_setup import *

--- a/tests/test_parser_create_user.py
+++ b/tests/test_parser_create_user.py
@@ -1,10 +1,7 @@
 import sys
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 import argparse
 from tabcmd.parsers.create_users_parser import CreateUserParser
 from .common_setup import *

--- a/tests/test_parser_decrypt_extracts.py
+++ b/tests/test_parser_decrypt_extracts.py
@@ -1,9 +1,5 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.decrypt_extracts_parser import DecryptExtractsParser
 from .common_setup import *

--- a/tests/test_parser_delete.py
+++ b/tests/test_parser_delete.py
@@ -1,10 +1,6 @@
 import sys
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.delete_parser import DeleteParser
 from .common_setup import *

--- a/tests/test_parser_delete_extracts.py
+++ b/tests/test_parser_delete_extracts.py
@@ -1,9 +1,5 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.delete_extracts_parser import DeleteExtractsParser
 from .common_setup import *

--- a/tests/test_parser_delete_group.py
+++ b/tests/test_parser_delete_group.py
@@ -1,10 +1,6 @@
 import sys
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.delete_group_parser import DeleteGroupParser
 from .common_setup import *

--- a/tests/test_parser_delete_site_user.py
+++ b/tests/test_parser_delete_site_user.py
@@ -1,10 +1,7 @@
 import sys
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 import argparse
 from tabcmd.parsers.delete_site_users_parser import DeleteSiteUsersParser
 from .common_setup import *

--- a/tests/test_parser_edit_site.py
+++ b/tests/test_parser_edit_site.py
@@ -1,9 +1,5 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.edit_site_parser import EditSiteParser
 from .common_setup import *

--- a/tests/test_parser_encrypt_extracts.py
+++ b/tests/test_parser_encrypt_extracts.py
@@ -1,9 +1,5 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.encrypt_extracts_parser import EncryptExtractsParser
 from .common_setup import *

--- a/tests/test_parser_export.py
+++ b/tests/test_parser_export.py
@@ -1,9 +1,5 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.export_parser import ExportParser
 from .common_setup import *

--- a/tests/test_parser_get_url.py
+++ b/tests/test_parser_get_url.py
@@ -1,9 +1,5 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.get_url_parser import GetUrlParser
 from .common_setup import *

--- a/tests/test_parser_list_sites.py
+++ b/tests/test_parser_list_sites.py
@@ -1,9 +1,5 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.list_sites_parser import ListSitesParser
 from .common_setup import *

--- a/tests/test_parser_login.py
+++ b/tests/test_parser_login.py
@@ -1,9 +1,5 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.login_parser import LoginParser
 from .common_setup import *

--- a/tests/test_parser_publish.py
+++ b/tests/test_parser_publish.py
@@ -1,9 +1,5 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.publish_parser import PublishParser
 from .common_setup import *

--- a/tests/test_parser_publish_samples.py
+++ b/tests/test_parser_publish_samples.py
@@ -1,9 +1,5 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.publish_samples_parser import PublishSamplesParser
 from .common_setup import *

--- a/tests/test_parser_reencrypt_extracts.py
+++ b/tests/test_parser_reencrypt_extracts.py
@@ -1,9 +1,5 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.reencrypt_parser import ReencryptExtractsParser
 from .common_setup import *

--- a/tests/test_parser_runschedule.py
+++ b/tests/test_parser_runschedule.py
@@ -1,9 +1,5 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import argparse
 from tabcmd.parsers.runschedule_parser import RunScheduleParser
 from .common_setup import *


### PR DESCRIPTION
The standard library has had mock as part of unittest since Python 3.3, so no reason now to wrap it with a try...except block.

A lot of these weren't really used though, so deleted where it didn't matter