### PR TITLE
Jac/publish samples

### DIFF
--- a/tabcmd/commands/project/publish_samples_command.py
+++ b/tabcmd/commands/project/publish_samples_command.py
@@ -2,6 +2,7 @@ from tabcmd.execution.global_options import *
 from tabcmd.commands.auth.session import Session
 from tabcmd.commands.server import Server
 from tabcmd.execution.logger_config import log
+from tabcmd.commands.constants import Errors
 
 
 class PublishSamplesCommand(Server):
@@ -23,16 +24,26 @@ class PublishSamplesCommand(Server):
             help="Publishes the Tableau samples into the specified project. If the project name includes spaces, "
             "enclose the entire name in quotes.",
         )
-        set_parent_project_arg(publish_samples_parser)
+        set_parent_project_arg(publish_samples_parser)  # args.parent_project_name
 
     @staticmethod
     def run_command(args):
-        logger = log(__name__, args.logging_level)
+        logger = log(__class__.__name__, args.logging_level)
         logger.debug("======================= Launching command =======================")
         session = Session()
         server = session.create_session(args)
-        if args.parent_path_name is not None:
-            project_path = Server.find_project_id(server, args.parent_path_name)
+        if args.parent_project_path is not None:
+            project_path = Server.get_project_by_name_and_parent_path(logger, server, None, args.parent_project_path)
         else:
             project_path = None
-        Errors.exit_with_error(logger, "Not yet implemented")
+        try:
+            project = PublishSamplesCommand.get_project_by_name_and_parent_path(
+                logger, server, args.project_name, project_path
+            )
+        except Exception as e:
+            Errors.exit_with_error(logger, "publishsamples expects the specified project to exist already", exception=e)
+
+        try:
+            server.projects.update(project, samples=True)
+        except Exception as e:
+            Errors.exit_with_error(logger, "Failed publishing samples to project", exception=e)

--- a/tests/commands/test_run_commands.py
+++ b/tests/commands/test_run_commands.py
@@ -20,7 +20,7 @@ from tabcmd.commands.extracts import (
 )
 from tabcmd.commands.group import create_group_command, delete_group_command
 from tabcmd.commands.help import help_command
-from tabcmd.commands.project import create_project_command, delete_project_command
+from tabcmd.commands.project import create_project_command, delete_project_command, publish_samples_command
 from tabcmd.commands.site import (
     create_site_command,
     delete_site_command,
@@ -215,13 +215,13 @@ class RunCommandsTest(unittest.TestCase):
         delete_project_command.DeleteProjectCommand.run_command(mock_args)
         mock_session.assert_called()
 
-    def test_publish_project(self, mock_session, mock_server):
+    def test_publish_samples(self, mock_session, mock_server):
         RunCommandsTest._set_up_session(mock_session, mock_server)
         mock_server.projects = getter
-        mock_args.parent_project_name = ""
-        # Not yet implemented
-        # publish_samples_command.PublishSamplesCommand.run_command(mock_args)
-        # mock_session.assert_called()
+        mock_args.project_name = "gloop"
+        mock_args.parent_project_path = ""
+        publish_samples_command.PublishSamplesCommand.run_command(mock_args)
+        mock_session.assert_called()
 
     # site
     def test_create_site(self, mock_session, mock_server):


### PR DESCRIPTION
Implemented publishsamples
Includes a new argument for my convenience: --continue-if-exists, so my repeated commands stop failing when I repeat a project name
Added significant e2e test coverage