### PR TITLE
Defect 1426854: [Tabcmd WAM] Login doesn't fail graciously with clear errors when the site is missing

### DIFF
--- a/src/commands/auth/session.py
+++ b/src/commands/auth/session.py
@@ -160,7 +160,8 @@ class Session:
             self.logger.info("=====   Username: {}".format(self.username))
         else:
             self.logger.info("=====   Token Name: {}".format(self.token_name))
-        self.logger.info(_("dataconnections.classes.tableau_server_site") + ": {}".format(self.site_name))
+        site_display_name = self.site_name or "Default Site"
+        self.logger.info(_("dataconnections.classes.tableau_server_site") + ": {}".format(site_display_name))
 
     def _validate_existing_signin(self):
         self.logger.info(_("session.continuing_session"))


### PR DESCRIPTION
New output: a) with valid account for default site
Creating new session
=====   Server: http://near-win1.tsi.lan
=====   Username: jfitzgerald
Tableau Server Site: Default Site
Connecting to the server...
Succeeded
b) with invalid account for default site
=====   Server: http://near-win1.tsi.lan
=====   Username: jfitzgerald
Tableau Server Site: Default Site
Connecting to the server...

        401001: Signin Error
                Error signing in to Tableau Server