### PR TITLE
Add command to list items of a given content type

### DIFF
--- a/tabcmd.py
+++ b/tabcmd.py
@@ -1,4 +1,4 @@
-from src import tabcmd
+from tabcmd import tabcmd
 
 if __name__ == "__main__":
     tabcmd.main()

--- a/tabcmd/commands/site/list_command.py
+++ b/tabcmd/commands/site/list_command.py
@@ -1,9 +1,10 @@
 import tableauserverclient as TSC
 
-from tabcmd.commands.auth.session import Session
-from tabcmd.commands.server import Server
-from tabcmd.commands.constants import Errors
-from tabcmd.execution.logger_config import log
+from src.commands.auth.session import Session
+from src.commands.server import Server
+from src.commands.constants import Errors
+from src.execution.logger_config import log
+from src.execution.localize import _
 
 
 class ListCommand(Server):
@@ -25,7 +26,7 @@ class ListCommand(Server):
     @staticmethod
     def run_command(args):
         logger = log(__name__, args.logging_level)
-        logger.debug("======================= Launching command =======================")
+        logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args)
         content_type = args.content
@@ -42,8 +43,8 @@ class ListCommand(Server):
 
             logger.info("===== Listing {0} content for user {1}...".format(content_type, session.username))
             for item in items:
-                print("NAME:", item.name)
-                print("      ID:", item.id)
+                print("NAME:".rjust(10), item.name)
+                print("ID:".rjust(10), item.id)
 
         except TSC.ServerResponseError as e:
             Errors.exit_with_error(logger, e)

--- a/tabcmd/commands/site/list_command.py
+++ b/tabcmd/commands/site/list_command.py
@@ -18,11 +18,7 @@ class ListCommand(Server):
 
     @staticmethod
     def define_args(list_parser):
-        list_parser.add_argument(
-             "content",
-             choices=["projects", "workbooks", "datasources"],
-             help="View content"
-        )
+        list_parser.add_argument("content", choices=["projects", "workbooks", "datasources"], help="View content")
 
     @staticmethod
     def run_command(args):
@@ -39,8 +35,6 @@ class ListCommand(Server):
                 items = server.workbooks.all()
             elif content_type == "datasources":
                 items = server.datasources.all()
-            else:
-                items = Server.get_sites(server)
 
             logger.info("===== Listing {0} content for user {1}...".format(content_type, session.username))
             for item in items:

--- a/tabcmd/commands/site/list_command.py
+++ b/tabcmd/commands/site/list_command.py
@@ -1,10 +1,11 @@
 import tableauserverclient as TSC
 
-from src.commands.auth.session import Session
-from src.commands.server import Server
-from src.commands.constants import Errors
-from src.execution.logger_config import log
-from src.execution.localize import _
+from tabcmd.commands.auth.session import Session
+from tabcmd.commands.constants import Errors
+from tabcmd.commands.server import Server
+from tabcmd.execution.global_options import *
+from tabcmd.execution.localize import _
+from tabcmd.execution.logger_config import log
 
 
 class ListCommand(Server):

--- a/tabcmd/commands/site/list_command.py
+++ b/tabcmd/commands/site/list_command.py
@@ -1,0 +1,49 @@
+import tableauserverclient as TSC
+
+from tabcmd.commands.auth.session import Session
+from tabcmd.commands.server import Server
+from tabcmd.commands.constants import Errors
+from tabcmd.execution.logger_config import log
+
+
+class ListCommand(Server):
+    """
+    Command to return a list of content the user can access
+    """
+
+    name: str = "list"
+    description: str = "List content items of a specified type"
+
+    @staticmethod
+    def define_args(list_parser):
+        list_parser.add_argument(
+             "content",
+             choices=["projects", "workbooks", "datasources"],
+             help="View content"
+        )
+
+    @staticmethod
+    def run_command(args):
+        logger = log(__name__, args.logging_level)
+        logger.debug("======================= Launching command =======================")
+        session = Session()
+        server = session.create_session(args)
+        content_type = args.content
+
+        try:
+            if content_type == "projects":
+                items = server.projects.all()
+            elif content_type == "workbooks":
+                items = server.workbooks.all()
+            elif content_type == "datasources":
+                items = server.datasources.all()
+            else:
+                items = Server.get_sites(server)
+
+            logger.info("===== Listing {0} content for user {1}...".format(content_type, session.username))
+            for item in items:
+                print("NAME:", item.name)
+                print("      ID:", item.id)
+
+        except TSC.ServerResponseError as e:
+            Errors.exit_with_error(logger, e)

--- a/tabcmd/commands/site/list_sites_command.py
+++ b/tabcmd/commands/site/list_sites_command.py
@@ -30,10 +30,9 @@ class ListSiteCommand(Server):
             sites, pagination = server.sites.get()
             logger.info(_("listsites.status").format(session.username))
             for site in sites:
-                print("NAME:", site.name)
-                print("SITEID:", site.content_url)
+                print("NAME:".rjust(10), site.name)
+                print("SITEID:".rjust(10), site.content_url)
                 if args.get_extract_encryption_mode:
                     print("EXTRACTENCRYPTION:", site.extract_encryption_mode)
-                print("")
         except TSC.ServerResponseError as e:
             Errors.exit_with_error(logger, e)

--- a/tabcmd/execution/map_of_commands.py
+++ b/tabcmd/execution/map_of_commands.py
@@ -23,6 +23,7 @@ from tabcmd.commands.site.list_sites_command import *
 from tabcmd.commands.user.add_users_command import *
 from tabcmd.commands.user.create_site_users import *
 from tabcmd.commands.user.delete_site_users_command import *
+from tabcmd.commands.site.list_command import *
 
 # from tabcmd.commands.user.create_users import *
 from tabcmd.commands.user.remove_users_command import *
@@ -51,6 +52,7 @@ class CommandsMap:
         GetUrl,
         HelpCommand,
         ListSiteCommand,
+        ListCommand,
         LoginCommand,
         LogoutCommand,
         PublishCommand,

--- a/tests/e2e/online_tests.py
+++ b/tests/e2e/online_tests.py
@@ -106,6 +106,11 @@ class OnlineCommandTest(unittest.TestCase):
         arguments = [command, "-w", wb_name]
         _test_command(arguments)
 
+    def _list(self, item_type: str):
+        command = "list"
+        arguments = [command, item_type]
+        _test_command(arguments)
+
     # actual tests
     TWBX_FILE_WITH_EXTRACT = "extract-data-access.twbx"
     TWBX_WITH_EXTRACT_NAME = "WorkbookWithExtract"
@@ -191,6 +196,10 @@ class OnlineCommandTest(unittest.TestCase):
         parent_path = "{0}/{1}".format(project_name, project_name)
         self._create_project(project_name, parent_path)
         time.sleep(indexing_sleep_time)
+
+    @pytest.mark.order(8)
+    def test_list_projects(self):
+        self._list("projects")
 
     @pytest.mark.order(9)
     def test_delete_projects(self):


### PR DESCRIPTION
I created this because I kept having to open up a site to see project/workbook names to call commands on :) 

Usage: tabcmd **list** _content_type_

content_type currently supports the options projects | workbooks | datasources
Display is modelled on listsites

example:
Creating new session
=====   Server: https://cd-near.online.dev.tabint.net/
=====   Username: jac.fitzgerald@salesforce.com
Tableau Server Site: cdnearcoresvcsauth
Connecting to the server...
Succeeded
===== Listing projects content for user jac.fitzgerald@salesforce.com...
     NAME: default
       ID: fb6171a2-acc0-4a3c-8cff-22962d7b45ee
     NAME: Samples
       ID: cf0e3d2f-82a0-4d9f-b1b5-9b03fff72064
     NAME: Admin Insights
       ID: de529fef-5c50-4dad-97a1-b31829278012
     NAME: test
       ID: 330d5e95-7818-48c4-ac92-ac7d79f9040b
     NAME: Project1
       ID: 5a470aa3-82c5-44f5-add2-44cc835c67ce
     NAME: ThatOldOld
       ID: d603a82f-b9f4-497e-b00a-b410de7f8e5e

===== Listing workbooks content for user jac.fitzgerald@salesforce.com...
     NAME: Superstore
       ID: b9d292ff-095e-43df-b8c0-da6462f5a7db
     NAME: New Workbook
       ID: 793c2d2a-6749-4029-b78c-700189d34a4e
     NAME: Admin Insights Starter
       ID: ff7bde68-b938-4b44-a96a-d392188adec6

===== Listing datasources content for user jac.fitzgerald@salesforce.com...
     NAME: Superstore Datasource
       ID: 8b2ddc4f-937c-4ecf-8d5a-6116e0615e07
     NAME: TS Users
       ID: 947c2570-5fcf-43e7-8617-d8140a5893a2
     NAME: TS Events
       ID: 9c932639-1e40-4ca7-9b0f-2ba604dbb244
     NAME: Site Content