### PR TITLE
Jac/e2e test workflow

### DIFF
--- a/.github/workflows/run-e2-tests.yml
+++ b/.github/workflows/run-e2-tests.yml
@@ -1,16 +1,16 @@
 name: Python tests
 
 on:
-  workflow_dispatch
-  inputs:
-    server:
-      required: true
-    site:
-      required: true
-    patname:
-      required: true
-    pat:
-      required: true
+  workflow_dispatch:
+    inputs:
+      server:
+        required: true
+      site:
+        required: true
+      patname:
+        required: true
+      pat:
+        required: true
 
 jobs:
   build:

--- a/.github/workflows/run-e2-tests.yml
+++ b/.github/workflows/run-e2-tests.yml
@@ -1,0 +1,45 @@
+name: Python tests
+
+on:
+  workflow_dispatch
+  inputs:
+    server:
+      required: true
+    site:
+      required: true
+    patname:
+      required: true
+    pat:
+      required: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3']
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python --version
+        python -m pip install --upgrade pip
+        pip install -e .[build]
+        pip install -e .[test]
+        doit version
+        python setup.py build
+
+    - name: Run e2e tests
+      run: | 
+        python -m tabcmd login --server "${{ github.event.inputs.server }}" --site "${{ github.event.inputs.site }}" --token-name "${{ github.event.inputs.patname }}" --token-value "${{ github.event.inputs.pat }}"
+        pytest -q tests\e2e\online_tests.py -r pfE

--- a/tests/e2e/online_tests.py
+++ b/tests/e2e/online_tests.py
@@ -18,6 +18,14 @@ workbook_name = "namebasic"
 # you can either run setup with a stored credentials file, or simply log in
 # before running the suite so a session is active
 
+# alpodev
+parent_location = "WAM"
+project_name = "Developer Platform"
+
+server_admin = False
+site_admin = True
+project_admin = True
+
 
 def _test_command(test_args: list[str]):
     # this will raise an exception if it gets a non-zero return code
@@ -43,18 +51,18 @@ class OnlineCommandTest(unittest.TestCase):
     def _create_project(self, project_name, parent_path=None):
         command = "createproject"
         arguments = [command, "--name", project_name]
-        if parent_path:
+        if parent_path or parent_location:
             arguments.append("--parent-project-path")
-            arguments.append(parent_path)
+            arguments.append(parent_path or parent_location)
         print(arguments)
         _test_command(arguments)
 
     def _delete_project(self, project_name, parent_path=None):
         command = "deleteproject"
         arguments = [command, project_name]
-        if parent_path:
+        if parent_path or parent_location:
             arguments.append("--parent-project-path")
-            arguments.append(parent_path)
+            arguments.append(parent_path or parent_location)
         _test_command(arguments)
 
     def _publish_samples(self, project_name):
@@ -135,6 +143,8 @@ class OnlineCommandTest(unittest.TestCase):
 
     @pytest.mark.order(2)
     def test_create_site_users(self):
+        if not server_admin and not site_admin:
+            pytest.skip("Must be server or site administrator to create site users")
         command = "createsiteusers"
         users = os.path.join("tests", "assets", "detailed_users.csv")
         arguments = [command, users, "--role", "Publisher"]
@@ -142,6 +152,8 @@ class OnlineCommandTest(unittest.TestCase):
 
     @pytest.mark.order(3)
     def test_creategroup(self):
+        if not server_admin and not site_admin:
+            pytest.skip("Must be server or site administrator to create groups")
         groupname = group_name
         command = "creategroup"
         arguments = [command, groupname]
@@ -149,6 +161,9 @@ class OnlineCommandTest(unittest.TestCase):
 
     @pytest.mark.order(4)
     def test_add_users_to_group(self):
+        if not server_admin and not site_admin:
+            pytest.skip("Must be server or site administrator to add to groups")
+
         groupname = group_name
         command = "addusers"
         filename = os.path.join("tests", "assets", "usernames.csv")
@@ -157,6 +172,9 @@ class OnlineCommandTest(unittest.TestCase):
 
     @pytest.mark.order(5)
     def test_remove_users_to_group(self):
+        if not server_admin and not site_admin:
+            pytest.skip("Must be server or site administrator to remove from groups")
+
         groupname = group_name
         command = "removeusers"
         filename = os.path.join("tests", "assets", "usernames.csv")
@@ -165,22 +183,19 @@ class OnlineCommandTest(unittest.TestCase):
 
     @pytest.mark.order(6)
     def test_deletegroup(self):
+        if not server_admin and not site_admin:
+            pytest.skip("Must be server or site administrator to delete groups")
+
         groupname = group_name
         command = "deletegroup"
         arguments = [command, groupname]
         _test_command(arguments)
 
-    @pytest.mark.order(7)
-    def test_publish_samples(self):
-        project_name = "sample-proj"
-        self._create_project(project_name)
-        time.sleep(indexing_sleep_time)
-
-        self._publish_samples(project_name)
-        self._delete_project(project_name)
-
     @pytest.mark.order(8)
     def test_create_projects(self):
+
+        if not project_admin:
+            pytest.skip("Must be project administrator to create projects")
         # project 1
         self._create_project(project_name)
         time.sleep(indexing_sleep_time)
@@ -194,12 +209,14 @@ class OnlineCommandTest(unittest.TestCase):
 
     @pytest.mark.order(9)
     def test_delete_projects(self):
+        if not project_admin:
+            pytest.skip("Must be project administrator to create projects")
         self._delete_project("project_name_2", project_name)  # project 2
         self._delete_project(project_name)
 
     @pytest.mark.order(9)
     def test_publish_samples(self):
-        self._publish_samples("Default")
+        self._publish_samples(project_name)
 
     @pytest.mark.order(10)
     def test_publish(self):
@@ -256,6 +273,7 @@ class OnlineCommandTest(unittest.TestCase):
 
     @pytest.mark.order(14)
     def test_refresh_extract(self):
+        # must be a datasource owned by the test user
         name_on_server = OnlineCommandTest.TWBX_WITH_EXTRACT_NAME
         self._refresh_extract(name_on_server)
         self._delete_wb(name_on_server)
@@ -292,11 +310,22 @@ class OnlineCommandTest(unittest.TestCase):
 
     @pytest.mark.order(16)
     def test_delete_site_users(self):
+        if not server_admin and not site_admin:
+            pytest.skip("Must be server or site administrator to delete site users")
+
         command = "deletesiteusers"
         users = os.path.join("tests", "assets", "usernames.csv")
         _test_command([command, users])
 
     @pytest.mark.order(20)
     def test_list_sites(self):
+        if not server_admin:
+            pytest.skip("Must be server administrator to list sites")
+
         command = "listsites"
-        _test_command([command])
+        try:
+            _test_command([command])
+        except Exception as E:
+            print("yay")
+            result = True
+        assert result


### PR DESCRIPTION
Adding a github workflow that allows people to run e2e tests against a server by manually entering the server credentials to kick it off. This will allow ad hoc e2e validation, and then perhaps we can store credentials as secrets or some other solution so it can be run on an automated schedule.