### PR TITLE
Implement command line and url parameters for get/export

### DIFF
--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -45,7 +45,7 @@ class Session:
 
         self.logging_level = "info"
         self._read_from_json()
-        self.logger = log(__name__, self.logging_level)  # instantiate here mostly for tests
+        self.logger = log(__class__.__name__, self.logging_level)  # instantiate here mostly for tests
         self.tableau_server = None  # this one is an object that doesn't get persisted in the file
 
     # called before we connect to the server
@@ -214,7 +214,7 @@ class Session:
         self._read_existing_state()
         self._update_session_data(args)
         self.logging_level = args.logging_level or self.logging_level
-        self.logger = log(__name__, self.logging_level)
+        self.logger = log(__class__.__name__, self.logging_level)
 
         credentials = None
         if args.password:

--- a/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
@@ -80,7 +80,7 @@ class DatasourcesAndWorkbooks(Server):
         setting = value.split("=")
         if ":iid" == setting[0]:
             logger.debug(":iid value ignored in url")
-        elif ":refresh" == setting[0] and request_options.is_truthy(setting):
+        elif ":refresh" == setting[0] and DatasourcesAndWorkbooks.is_truthy(setting[1]):
             # mypy is worried that this is readonly
             request_options.max_age = 0  # type:ignore
             logger.debug("Set max age to {} from {}".format(request_options.max_age, value))

--- a/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
@@ -25,7 +25,7 @@ class DatasourcesAndWorkbooks(Server):
             req_option.filter.add(TSC.Filter("contentUrl", TSC.RequestOptions.Operator.Equals, view_content_url))
             matching_views, paging = server.views.get(req_option)
         except TSC.ServerResponseError as e:
-            Errors.exit_with_error(logger, _("publish.errors.unexpected_server_response").format(""))
+            Errors.exit_with_error(logger, _("publish.errors.unexpected_server_response").format(e))
         if len(matching_views) < 1:
             Errors.exit_with_error(logger, message=_("errors.xmlapi.not_found"))
         return matching_views[0]
@@ -42,3 +42,57 @@ class DatasourcesAndWorkbooks(Server):
         if len(matching_workbooks) < 1:
             Errors.exit_with_error(logger, message=_("dataalerts.failure.error.workbookNotFound"))
         return matching_workbooks[0]
+
+    @staticmethod
+    def apply_values_from_url_params(request_options: TSC.PDFRequestOptions, url, logger) -> None:
+        # should be able to replace this with request_options._append_view_filters(params)
+        logger.debug(url)
+        try:
+            if "?" in url:
+                query = url.split("?")[1]
+                logger.trace("Query parameters: {}".format(query))
+            else:
+                logger.debug("No query parameters present in url")
+                return
+
+            params = query.split("&")
+            logger.trace(params)
+            for value in params:
+                if value.startswith(":"):
+                    DatasourcesAndWorkbooks.apply_option_value(request_options, value, logger)
+                else:  # it must be a filter
+                    DatasourcesAndWorkbooks.apply_filter_value(request_options, value, logger)
+
+        except BaseException as e:
+            logger.warn("Error building filter params", e)
+            # ExportCommand.log_stack(logger)  # type: ignore
+
+    @staticmethod
+    def apply_filter_value(request_options: TSC.PDFRequestOptions, value: str, logger) -> None:
+        # todo: do we need to strip Parameters.x -> x?
+        logger.trace("handling filter param {}".format(value))
+        data_filter = value.split("=")
+        request_options.vf(data_filter[0], data_filter[1])
+
+    @staticmethod
+    def apply_option_value(request_options: TSC.PDFRequestOptions, value: str, logger) -> None:
+        logger.trace("handling url option {}".format(value))
+        setting = value.split("=")
+        if ":iid" == setting[0]:
+            logger.debug(":iid value ignored in url")
+        elif ":refresh" == setting[0] and setting[1] in ["yes", "y", "YES", "Y", "1"]:
+            request_options.max_age = 0
+            logger.debug("Set max age to {} from {}".format(request_options.max_age, value))
+        elif ":size" == setting[0]:
+            height, width = setting[1].split(",")
+            logger.warn("Height/weight parameters not yet implemented ({})".format(value))
+        else:
+            logger.debug("Parameter[s] not recognized: {}".format(value))
+
+    @staticmethod
+    def apply_png_options(request_options: TSC.ImageRequestOptions, args, logger):
+        if args.height or args.width:
+            # only applicable for png
+            logger.warn("Height/width arguments not yet implemented in export")
+        if args.image_resolution:
+            request_options.image_resolution = args.image_resolution

--- a/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
@@ -101,3 +101,17 @@ class DatasourcesAndWorkbooks(Server):
             logger.warn("Height/width arguments not yet implemented in export")
         if args.image_resolution:
             request_options.image_resolution = args.image_resolution
+
+    @staticmethod
+    def save_to_data_file(logger, output, filename):
+        logger.info(_("httputils.found_attachment").format(filename))
+        with open(filename, "wb") as f:
+            f.writelines(output)
+            logger.info(_("export.success").format("", filename))
+
+    @staticmethod
+    def save_to_file(logger, output, filename):
+        logger.info(_("httputils.found_attachment").format(filename))
+        with open(filename, "wb") as f:
+            f.write(output)
+            logger.info(_("export.success").format("", filename))

--- a/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
@@ -81,7 +81,8 @@ class DatasourcesAndWorkbooks(Server):
         if ":iid" == setting[0]:
             logger.debug(":iid value ignored in url")
         elif ":refresh" == setting[0] and setting[1] in ["yes", "y", "YES", "Y", "1"]:
-            request_options.max_age = 0
+            # mypy is worried that this is readonly
+            request_options.max_age = 0  # type:ignore
             logger.debug("Set max age to {} from {}".format(request_options.max_age, value))
         elif ":size" == setting[0]:
             height, width = setting[1].split(",")

--- a/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
@@ -80,7 +80,7 @@ class DatasourcesAndWorkbooks(Server):
         setting = value.split("=")
         if ":iid" == setting[0]:
             logger.debug(":iid value ignored in url")
-        elif ":refresh" == setting[0] and setting[1] in ["yes", "y", "YES", "Y", "1"]:
+        elif ":refresh" == setting[0] and request_options.is_truthy(setting):
             # mypy is worried that this is readonly
             request_options.max_age = 0  # type:ignore
             logger.debug("Set max age to {} from {}".format(request_options.max_age, value))
@@ -89,6 +89,10 @@ class DatasourcesAndWorkbooks(Server):
             logger.warn("Height/weight parameters not yet implemented ({})".format(value))
         else:
             logger.debug("Parameter[s] not recognized: {}".format(value))
+
+    @staticmethod
+    def is_truthy(value: str):
+        return value.lower() in ["yes", "y", "1", "true"]
 
     @staticmethod
     def apply_png_options(request_options: TSC.ImageRequestOptions, args, logger):

--- a/tabcmd/commands/datasources_and_workbooks/export_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/export_command.py
@@ -167,17 +167,3 @@ class ExportCommand(DatasourcesAndWorkbooks):
         workbook = name_parts[0]
         view = "{}/sheets/{}".format(workbook, name_parts[1])
         return view, workbook
-
-    @staticmethod
-    def save_to_data_file(logger, output, filename):
-        logger.info(_("httputils.found_attachment").format(filename))
-        with open(filename, "wb") as f:
-            f.writelines(output)
-            logger.info(_("export.success").format("", filename))
-
-    @staticmethod
-    def save_to_file(logger, output, filename):
-        logger.info(_("httputils.found_attachment").format(filename))
-        with open(filename, "wb") as f:
-            f.write(output)
-            logger.info(_("export.success").format("", filename))

--- a/tabcmd/commands/datasources_and_workbooks/get_url_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/get_url_command.py
@@ -150,9 +150,7 @@ class GetUrl(DatasourcesAndWorkbooks):
             DatasourcesAndWorkbooks.apply_values_from_url_params(req_option_pdf, args.url, logger)
             server.views.populate_pdf(view_item, req_option_pdf)
             filename = GetUrl.filename_from_args(args.filename, view_item.name, "pdf")
-            with open(filename, "wb") as f:
-                f.write(view_item.pdf)
-            logger.info(_("export.success").format(view_item.name, filename))
+            DatasourcesAndWorkbooks.save_to_file(logger, view_item.pdf, filename)
         except TSC.ServerResponseError as e:
             Errors.exit_with_error(logger, _("publish.errors.unexpected_server_response"), e)
 
@@ -163,12 +161,9 @@ class GetUrl(DatasourcesAndWorkbooks):
             logger.debug(_("content_type.view") + ": {}".format(view_item.name))
             req_option_csv = TSC.ImageRequestOptions(maxage=1)
             DatasourcesAndWorkbooks.apply_values_from_url_params(req_option_csv, args.url, logger)
-            DatasourcesAndWorkbooks.apply_png_options(req_option_csv, args.url, logger)
             server.views.populate_image(view_item, req_option_csv)
             filename = GetUrl.filename_from_args(args.filename, view_item.name, "png")
-            with open(filename, "wb") as f:
-                f.write(view_item.image)
-            logger.info(_("export.success").format(view_item.name, filename))
+            DatasourcesAndWorkbooks.save_to_file(logger, view_item.image, filename)
         except TSC.ServerResponseError as e:
             Errors.exit_with_error(logger, _("publish.errors.unexpected_server_response"), e)
 
@@ -178,12 +173,10 @@ class GetUrl(DatasourcesAndWorkbooks):
             view_item: TSC.ViewItem = GetUrl.get_view_by_content_url(logger, server, view_url)
             logger.debug(_("content_type.view") + ": {}".format(view_item.name))
             req_option_csv = TSC.CSVRequestOptions(maxage=1)
-            server.views.populate_csv(view_item, req_option_csv)
             DatasourcesAndWorkbooks.apply_values_from_url_params(req_option_csv, args.url, logger)
+            server.views.populate_csv(view_item, req_option_csv)
             file_name_with_path = GetUrl.filename_from_args(args.filename, view_item.name, "csv")
-            with open(file_name_with_path, "wb") as f:
-                f.writelines(view_item.csv)
-            logger.info(_("export.success").format(view_item.name, file_name_with_path))
+            DatasourcesAndWorkbooks.save_to_data_file(logger, view_item.csv, file_name_with_path)
         except TSC.ServerResponseError as e:
             Errors.exit_with_error(logger, _("publish.errors.unexpected_server_response"), e)
         except Exception as e:

--- a/tabcmd/commands/user/user_data.py
+++ b/tabcmd/commands/user/user_data.py
@@ -273,4 +273,3 @@ class UserCommand(Server):
             if number_of_errors > max_printing:
                 logger.info(_("importcsvsummary.error.too_many_errors"))
                 logger.info(_("importcsvsummary.remainingerrors"))
-

--- a/tabcmd/execution/logger_config.py
+++ b/tabcmd/execution/logger_config.py
@@ -5,9 +5,9 @@ path = os.path.dirname(os.path.abspath(__file__))
 
 FORMATS = {
     logging.ERROR: "%(asctime)s %(levelname)-5s:(%(name)-10s %(filename)-10s: %(lineno)d): %(message)-30s",
-    logging.WARN: "%(asctime)s %(levelname)s : (%(name)-10s %(filename)-10s: %(lineno)d): %(message)-30s",
+    logging.WARN: "%(asctime)s %(levelname)-5s: (%(name)-10s %(filename)-10s: %(lineno)d): %(message)-30s",
     logging.INFO: "%(message)-30s",
-    logging.DEBUG: "%(asctime)s %(levelname)s : (%(name)-10s %(filename)-10s: %(lineno)d): %(message)-30s",
+    logging.DEBUG: "%(asctime)s %(levelname)-5s: (%(name)-10s %(filename)-10s: %(lineno)d): %(message)-30s",
 }
 
 # https://stackoverflow.com/questions/2183233/how-to-add-a-custom-loglevel-to-pythons-logging-facility
@@ -39,7 +39,6 @@ def add_trace_level():
     trace_level: int = logging.DEBUG - 5
     add_log_level("TRACE", trace_level)
     FORMATS[trace_level] = FORMATS[logging.ERROR]
-
 
 
 def configure_log(name: str, logging_level_input: str):

--- a/tests/commands/test_geturl_utils.py
+++ b/tests/commands/test_geturl_utils.py
@@ -8,6 +8,15 @@ from tabcmd.commands.datasources_and_workbooks.get_url_command import *
 from tabcmd.commands.datasources_and_workbooks.export_command import *
 from tabcmd.commands.server import Server
 
+mock_args = argparse.Namespace()
+mock_args.pagelayout = None
+mock_args.pagesize = None
+mock_args.image_resolution = None
+mock_args.width = None
+mock_args.height = None
+mock_args.filename = None
+mock_args.filter = None
+
 mock_logger = mock.MagicMock()
 
 fake_item = mock.MagicMock(TSC.ViewItem)
@@ -51,10 +60,13 @@ class GeturlTests(unittest.TestCase):
         assert GetUrl.get_name_without_possible_extension(filename) == filename
 
     def test_get_workbook_name(self):
-        assert GetUrl.get_workbook_name(mock_logger, "/workbooks/wbname") == "wbname"
+        assert GetUrl.get_workbook_name("workbooks/wbname", mock_logger) == "wbname"
 
     def test_view_name(self):
-        assert GetUrl.get_view_url("/views/wb-name/view-name") == "wb-name/sheets/view-name"
+        assert GetUrl.get_view_url("views/wb-name/view-name", None) == "wb-name/sheets/view-name"
+
+    def test_view_name_with_url_params(self):
+        assert GetUrl.get_view_url("views/wb-name/view-name?:refresh=y", None) == "wb-name/sheets/view-name"
 
     """
     GetUrl.get_view_without_extension(view_name)
@@ -93,12 +105,21 @@ class ExportTests(unittest.TestCase):
         assert view is None
         assert wb is None
 
+    def test_apply_filter(self):
+        url = "wb-name/view-name?param1=value1"
+        options = TSC.PDFRequestOptions()
+        assert options.view_filters is not None
+        assert len(options.view_filters) is 0
+        ExportCommand.apply_filter_value(options, "param1=value1", mock_logger)
+        assert len(options.view_filters) == 1
+        assert options.view_filters[0] == ("param1", "value1")
+
     def test_extract_query_params(self):
         url = "wb-name/view-name?param1=value1"
         options = TSC.PDFRequestOptions()
         assert options.view_filters is not None
         assert len(options.view_filters) is 0
-        ExportCommand.extract_filter_values_from_url_params(options, url)
+        ExportCommand.apply_values_from_url_params(options, url, mock_logger)
         assert len(options.view_filters) == 1
         assert options.view_filters[0] == ("param1", "value1")
 
@@ -108,7 +129,8 @@ class ExportTests(unittest.TestCase):
         mock_server.views.csv = mock.MagicMock()
         mock_view = tableauserverclient.ViewItem()
         url = "wb-name/view-name?param1=value1"
-        ExportCommand.download_csv(mock_server, mock_view, url, mock_logger)
+        mock_args.url = url
+        ExportCommand.download_csv(mock_server, mock_view, mock_args, mock_logger)
 
     @mock.patch("tableauserverclient.Server")
     def test_download_image(self, mock_server):
@@ -116,7 +138,8 @@ class ExportTests(unittest.TestCase):
         mock_server.views.png = mock.MagicMock()
         mock_view = tableauserverclient.ViewItem()
         url = "wb-name/view-name?param1=value1"
-        ExportCommand.download_png(mock_server, mock_view, url, mock_logger)
+        mock_args.url = url
+        ExportCommand.download_png(mock_server, mock_view, mock_args, mock_logger)
 
     @mock.patch("tableauserverclient.Server")
     def test_download_view_pdf(self, mock_server):
@@ -124,7 +147,8 @@ class ExportTests(unittest.TestCase):
         mock_server.views.pdf = mock.MagicMock()
         mock_view = tableauserverclient.ViewItem()
         url = "wb-name/view-name?param1=value1"
-        ExportCommand.download_view_pdf(mock_server, mock_view, url, mock_logger)
+        mock_args.url = url
+        ExportCommand.download_view_pdf(mock_server, mock_view, mock_args, mock_logger)
 
     @mock.patch("tableauserverclient.Server")
     def test_download_wb_pdf(self, mock_server):
@@ -132,7 +156,8 @@ class ExportTests(unittest.TestCase):
         mock_server.workbooks.pdf = mock.MagicMock()
         mock_view = tableauserverclient.ViewItem()
         url = "wb-name/view-name?param1=value1"
-        ExportCommand.download_wb_pdf(mock_server, mock_view, url, mock_logger)
+        mock_args.url = url
+        ExportCommand.download_wb_pdf(mock_server, mock_view, mock_args, mock_logger)
 
     def test_save_to_binary_file(self):
         mock_content = bytes()

--- a/tests/commands/test_geturl_utils.py
+++ b/tests/commands/test_geturl_utils.py
@@ -105,24 +105,6 @@ class ExportTests(unittest.TestCase):
         assert view is None
         assert wb is None
 
-    def test_apply_filter(self):
-        url = "wb-name/view-name?param1=value1"
-        options = TSC.PDFRequestOptions()
-        assert options.view_filters is not None
-        assert len(options.view_filters) is 0
-        ExportCommand.apply_filter_value(options, "param1=value1", mock_logger)
-        assert len(options.view_filters) == 1
-        assert options.view_filters[0] == ("param1", "value1")
-
-    def test_extract_query_params(self):
-        url = "wb-name/view-name?param1=value1"
-        options = TSC.PDFRequestOptions()
-        assert options.view_filters is not None
-        assert len(options.view_filters) is 0
-        ExportCommand.apply_values_from_url_params(options, url, mock_logger)
-        assert len(options.view_filters) == 1
-        assert options.view_filters[0] == ("param1", "value1")
-
     @mock.patch("tableauserverclient.Server")
     def test_download_csv(self, mock_server):
         mock_server.views = mock.MagicMock()
@@ -158,6 +140,48 @@ class ExportTests(unittest.TestCase):
         url = "wb-name/view-name?param1=value1"
         mock_args.url = url
         ExportCommand.download_wb_pdf(mock_server, mock_view, mock_args, mock_logger)
+
+
+@mock.patch("tableauserverclient.ViewItem", fake_item)
+class DS_WB_Tests(unittest.TestCase):
+    def test_apply_filter(self):
+        url = "wb-name/view-name?param1=value1"
+        options = TSC.PDFRequestOptions()
+        assert options.view_filters is not None
+        assert len(options.view_filters) is 0
+        ExportCommand.apply_filter_value(options, "param1=value1", mock_logger)
+        assert len(options.view_filters) == 1
+        assert options.view_filters[0] == ("param1", "value1")
+
+    def test_extract_query_params(self):
+        url = "wb-name/view-name?param1=value1"
+        options = TSC.PDFRequestOptions()
+        assert options.view_filters is not None
+        assert len(options.view_filters) is 0
+        ExportCommand.apply_values_from_url_params(options, url, mock_logger)
+        assert len(options.view_filters) == 1
+        assert options.view_filters[0] == ("param1", "value1")
+
+    def test_refresh_true(self):
+        url = "wb-name/view-name?:refresh=TRUE"
+        options = TSC.PDFRequestOptions()
+        assert options.max_age == -1
+        ExportCommand.apply_values_from_url_params(options, url, mock_logger)
+        assert options.max_age == 0
+
+    def test_refresh_yes(self):
+        url = "wb-name/view-name?:refresh=yes"
+        options = TSC.PDFRequestOptions()
+        assert options.max_age == -1
+        ExportCommand.apply_values_from_url_params(options, url, mock_logger)
+        assert options.max_age == 0
+
+    def test_refresh_y(self):
+        url = "wb-name/view-name?:refresh=y"
+        options = TSC.PDFRequestOptions()
+        assert options.max_age == -1
+        ExportCommand.apply_values_from_url_params(options, url, mock_logger)
+        assert options.max_age == 0
 
     def test_save_to_binary_file(self):
         mock_content = bytes()

--- a/tests/e2e/online_tests.py
+++ b/tests/e2e/online_tests.py
@@ -51,7 +51,7 @@ class OnlineCommandTest(unittest.TestCase):
     def _create_project(self, project_name, parent_path=None):
         command = "createproject"
         arguments = [command, "--name", project_name]
-        if parent_path or parent_location:
+        if parent_path:
             arguments.append("--parent-project-path")
             arguments.append(parent_path)
         _test_command(arguments)
@@ -59,9 +59,9 @@ class OnlineCommandTest(unittest.TestCase):
     def _delete_project(self, project_name, parent_path=None):
         command = "deleteproject"
         arguments = [command, project_name]
-        if parent_path or parent_location:
+        if parent_path:
             arguments.append("--parent-project-path")
-            arguments.append(parent_path or parent_location)
+            arguments.append(parent_path)
         _test_command(arguments)
 
     def _publish_samples(self, project_name):


### PR DESCRIPTION
- refresh parameter is used to set maxAge
- filters can be set either with --filter option or in url parameters
- Height/width parameters are not yet implemented, b/c they are not available in the underlying REST API
- orientation can be set in _get_ command