### PR TITLE
tfs 1427025: Confusing error message related to sign-in

### DIFF
--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -245,8 +245,8 @@ class Session:
             signed_in_object = self._sign_in(credentials)
 
         if not signed_in_object:
-            missing_var = _("editdomain.errors.requires_nickname_name").format("username", "token")
-            Errors.exit_with_error(self.logger, _("session.errors.missing_arguments").format(missing_var))
+            message = "Run 'tabcmd login -h' for details on required arguments"
+            Errors.exit_with_error(self.logger, _("session.errors.missing_arguments").format(message))
         if args.no_cookie:
             self._remove_json()
         else:

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -44,8 +44,8 @@ class Session:
         self.timeout = None
 
         self.logging_level = "info"
-        self._read_from_json()
         self.logger = log(__class__.__name__, self.logging_level)  # instantiate here mostly for tests
+        self._read_from_json()
         self.tableau_server = None  # this one is an object that doesn't get persisted in the file
 
     # called before we connect to the server

--- a/tabcmd/execution/localize.py
+++ b/tabcmd/execution/localize.py
@@ -68,8 +68,8 @@ def define_locale_dir(logger):
     except AttributeError as e:
         logger.debug(e)
     """
-    print(locale_dir)
-    print(listdir(locale_dir))
+    logger.debug(locale_dir)
+    logger.debug(listdir(locale_dir))
     return locale_dir
 
 


### PR DESCRIPTION
The error message was too specific: made it generic for any missing argument and added a tip to see the argument options. New output:

c:\dev\tabcmd2>tabcmd listsites
logging: INFO
constants.py: Cannot sign in because of missing arguments: Run 'tabcmd login -h' for details on required arguments