### PR TITLE
Improve confusing help message for signing in

### DIFF
--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -245,8 +245,8 @@ class Session:
             signed_in_object = self._sign_in(credentials)
 
         if not signed_in_object:
-            missing_var = _("editdomain.errors.requires_nickname_name").format("username", "token")
-            Errors.exit_with_error(self.logger, _("session.errors.missing_arguments").format(missing_var))
+            message = "Run 'tabcmd login -h' for details on required arguments"
+            Errors.exit_with_error(self.logger, _("session.errors.missing_arguments").format(message))
         if args.no_cookie:
             self._remove_json()
         else:

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -44,8 +44,8 @@ class Session:
         self.timeout = None
 
         self.logging_level = "info"
-        self._read_from_json()
         self.logger = log(__class__.__name__, self.logging_level)  # instantiate here mostly for tests
+        self._read_from_json()
         self.tableau_server = None  # this one is an object that doesn't get persisted in the file
 
     # called before we connect to the server

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -214,7 +214,7 @@ class Session:
         self._read_existing_state()
         self._update_session_data(args)
         self.logging_level = args.logging_level or self.logging_level
-        self.logger = log(__class__.__name__, self.logging_level)
+        self.logger = self.logger or log(__class__.__name__, self.logging_level)
 
         credentials = None
         if args.password:

--- a/tabcmd/execution/localize.py
+++ b/tabcmd/execution/localize.py
@@ -68,8 +68,8 @@ def define_locale_dir(logger):
     except AttributeError as e:
         logger.debug(e)
     """
-    print(locale_dir)
-    print(listdir(locale_dir))
+    logger.debug(locale_dir)
+    logger.debug(listdir(locale_dir))
     return locale_dir
 
 


### PR DESCRIPTION
old: said username/token was missing even when it was there

c:\dev\tabcmd2>python -m tabcmd login -u jfitzgerald@tableau.com
constants.py: Cannot sign in because of missing arguments: Either a ''username'' option or a ''token'' option must be specified

new: says some arguments are missing, see help for info on required args

c:\dev\tabcmd2>python -m tabcmd login -u jfitzgerald@tableau.com
constants.py: Cannot sign in because of missing arguments: Run 'tabcmd login -h' for details on required arguments