### PR TITLE
Jac/delete site

### DIFF
--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -55,10 +55,14 @@ class Session:
         # last_login_using and tableau_server are internal data
         # self.command = args.???
         self.username = args.username or self.username
+        self.username.lower()
+        self.server_url = args.server.lower() or self.server_url or "http://localhost"
+        if args.server is not None:
+            self.site_name = None
         self.site_name = args.site_name or self.site_name or ""
+        self.site_name.lower()
         if self.site_name == "default":
             self.site_name = ""
-        self.server_url = args.server or self.server_url or "http://localhost"
         self.logging_level = args.logging_level or self.logging_level
         self.password_file = args.password_file
         self.token_name = args.token_name or self.token_name

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -54,13 +54,14 @@ class Session:
         # user id and site id are never passed in as args
         # last_login_using and tableau_server are internal data
         # self.command = args.???
-        self.username = args.username or self.username
+        self.username = args.username or self.username or ""
         self.username.lower()
-        self.server_url = args.server.lower() or self.server_url or "http://localhost"
+        self.server_url = args.server or self.server_url or "http://localhost"
+        self.server_url = self.server_url.lower()
         if args.server is not None:
             self.site_name = None
         self.site_name = args.site_name or self.site_name or ""
-        self.site_name.lower()
+        self.site_name = self.site_name.lower()
         if self.site_name == "default":
             self.site_name = ""
         self.logging_level = args.logging_level or self.logging_level

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -55,7 +55,7 @@ class Session:
         # last_login_using and tableau_server are internal data
         # self.command = args.???
         self.username = args.username or self.username or ""
-        self.username.lower()
+        self.username = self.username.lower()
         self.server_url = args.server or self.server_url or "http://localhost"
         self.server_url = self.server_url.lower()
         if args.server is not None:

--- a/tabcmd/commands/server.py
+++ b/tabcmd/commands/server.py
@@ -91,7 +91,7 @@ class Server:
         return site_item
 
     @staticmethod
-    def get_site_by_name(logger, server, site_name):
+    def get_site_by_name(logger, server, site_name) -> TSC.SiteItem:
         try:
             # sites don't use the normal filter
             site_item = server.sites.get_by_name(site_name)

--- a/tabcmd/commands/site/delete_site_command.py
+++ b/tabcmd/commands/site/delete_site_command.py
@@ -17,7 +17,7 @@ class DeleteSiteCommand(Server):
 
     @staticmethod
     def define_args(delete_site_parser):
-        delete_site_parser.add_argument("site_name_to_delete", metavar="site-name", help="name of site to delete")
+        delete_site_parser.add_argument("site_name_to_delete", metavar="site-name", help=strings[2])
 
     @staticmethod
     def run_command(args):
@@ -26,8 +26,19 @@ class DeleteSiteCommand(Server):
         session = Session()
         server = session.create_session(args)
         site_url = Server.get_site_by_name(logger, server, args.site_name_to_delete).content_url
+        logger.debug(strings[3].format(site_url))
         try:
             server.sites.delete(site_url)
-            logger.info("Successfully deleted the site")
+            logger.info(strings[0])
         except TSC.ServerResponseError as e:
-            Errors.exit_with_error(logger, "Error deleting site", e)
+            Errors.exit_with_error(logger, strings[1], e)
+        except BaseException as e:
+            Errors.exit_with_error(logger, strings[4], e)
+
+strings = [
+"Successfully deleted the site",
+"Server responded with an error while deleting site",
+"name of site to delete",
+"Deleting site  {}",
+"Error while deleting site"
+]

--- a/tabcmd/commands/site/delete_site_command.py
+++ b/tabcmd/commands/site/delete_site_command.py
@@ -25,21 +25,22 @@ class DeleteSiteCommand(Server):
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args)
-        site_url = Server.get_site_by_name(logger, server, args.site_name_to_delete).content_url
-        logger.debug(strings[3].format(site_url))
+        target_site: TSC.SiteItem = Server.get_site_by_name(logger, server, args.site_name_to_delete)
+        target_site_id = target_site.id
+        logger.debug(strings[3].format(target_site_id, server.site_id))
         try:
-            server.sites.delete(site_url)
-            logger.info(strings[0])
+            server.sites.delete(target_site_id)
         except TSC.ServerResponseError as e:
             Errors.exit_with_error(logger, strings[1], e)
         except BaseException as e:
             Errors.exit_with_error(logger, strings[4], e)
+        logger.info(strings[0].format(args.site_name_to_delete))
 
 
 strings = [
-    "Successfully deleted the site",
+    "Successfully deleted site {}",
     "Server responded with an error while deleting site",
     "name of site to delete",
-    "Deleting site  {}",
+    "Deleting site {0}, logged in to site {1}",
     "Error while deleting site",
 ]

--- a/tabcmd/commands/site/delete_site_command.py
+++ b/tabcmd/commands/site/delete_site_command.py
@@ -35,10 +35,11 @@ class DeleteSiteCommand(Server):
         except BaseException as e:
             Errors.exit_with_error(logger, strings[4], e)
 
+
 strings = [
-"Successfully deleted the site",
-"Server responded with an error while deleting site",
-"name of site to delete",
-"Deleting site  {}",
-"Error while deleting site"
+    "Successfully deleted the site",
+    "Server responded with an error while deleting site",
+    "name of site to delete",
+    "Deleting site  {}",
+    "Error while deleting site",
 ]

--- a/tabcmd/execution/parent_parser.py
+++ b/tabcmd/execution/parent_parser.py
@@ -56,7 +56,7 @@ class ParentParser:
 
         parser.add_argument(
             "--continue-if-exists",
-            action="store_false",
+            action="store_true",
             help="Treat resource conflicts as item creation success e.g project already exists",
         )
 

--- a/tests/commands/test_session.py
+++ b/tests/commands/test_session.py
@@ -45,7 +45,7 @@ mock_data_from_json = Namespace(
     no_prompt=False,
 )
 
-fakeserver = "http://SRVR"
+fakeserver = "http://SRVR".lower()
 
 
 def _set_mocks_for_json_file_saved_username(mock_json_load, auth_token, username):

--- a/tests/parsers/test_parser_add_user.py
+++ b/tests/parsers/test_parser_add_user.py
@@ -6,6 +6,7 @@ from .common_setup import *
 
 commandname = "addusers"
 
+
 class AddUsersParserTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/parsers/test_parser_add_user.py
+++ b/tests/parsers/test_parser_add_user.py
@@ -6,7 +6,6 @@ from .common_setup import *
 
 commandname = "addusers"
 
-
 class AddUsersParserTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
functional changes
1. change "continue if exists" to false, to match behavior of original tabcmd
2.  fix bug where we tried to call delete on the content url, not the site id
3. make sure to clear the site name for the session when the server name changes
4. run toLower on input so that comparisons with existing saved options is valid