### PR TITLE
add role and auth args

### DIFF
--- a/tabcmd/commands/datasources_and_workbooks/export_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/export_command.py
@@ -32,7 +32,6 @@ class ExportCommand(DatasourcesAndWorkbooks):
             help="page orientation (landscape or portrait) of the exported PDF",
         )
         group.add_argument(
-
             "--pagesize",
             choices=[
                 pagesize.A3,

--- a/tabcmd/commands/datasources_and_workbooks/get_url_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/get_url_command.py
@@ -60,7 +60,6 @@ class GetUrl(DatasourcesAndWorkbooks):
                 return content_type
         Errors.exit_with_error(logger, message=_("get.errors.invalid_content_type").format(url))
 
-
     @staticmethod
     def explain_expected_url(logger, url: str, command: str):
         view_example = "/views/<workbookname>/<viewname>[.ext]"

--- a/tabcmd/commands/user/create_site_users.py
+++ b/tabcmd/commands/user/create_site_users.py
@@ -1,6 +1,7 @@
 import tableauserverclient as TSC
 
 from tabcmd.commands.auth.session import Session
+from tabcmd.commands.constants import Errors
 from tabcmd.execution.global_options import *
 from tabcmd.execution.localize import _
 from tabcmd.execution.logger_config import log
@@ -20,9 +21,10 @@ class CreateSiteUsersCommand(UserCommand):
     @staticmethod
     def define_args(create_site_users_parser):
         args_group = create_site_users_parser.add_argument_group(title=CreateSiteUsersCommand.name)
-        set_role_arg(args_group)
+        UserCommand.set_role_arg(args_group)
         set_users_file_positional(args_group)
         set_completeness_options(args_group)
+        UserCommand.set_auth_arg(args_group)
 
     @staticmethod
     def run_command(args):
@@ -44,17 +46,27 @@ class CreateSiteUsersCommand(UserCommand):
         error_list = []
         for user_obj in user_obj_list:
             try:
+                if args.role:
+                    user_obj.site_role = args.role  # tsc is case sensitive
+                if args.auth_type:
+                    user_obj.auth_setting = args.auth_type
                 number_of_users_listed += 1
                 result = server.users.add(user_obj)
                 logger.info(_("tabcmd.result.success.create_user").format(user_obj.name))
                 number_of_users_added += 1
             except TSC.ServerResponseError as e:
-                number_of_errors += 1
-                error_list.append(e)
                 logger.debug(e)
+                if Errors.is_resource_conflict(e) and args.continue_if_exists:
+                    logger.debug(_("createsite.errors.site_name_already_exists").format(args.new_site_name))
+                else:
+                    number_of_errors += 1
+                    logger.debug(number_of_errors)
+                    error_list.append(e.summary + ": " + e.detail)
+                logger.debug(error_list)
         logger.info(_("session.monitorjob.percent_complete").format(100))
         logger.info(_("importcsvsummary.line.processed").format(number_of_users_listed))
         logger.info(_("importcsvsummary.line.skipped").format(number_of_errors))
         logger.info(_("importcsvsummary.users.added.count").format(number_of_users_added))
         if number_of_errors > 0:
-            logger.info(_("importcsvsummary.error.details").format(error_list))
+            logger.info(_("importcsvsummary.error.details"))
+            logger.info(error_list)

--- a/tabcmd/commands/user/create_site_users.py
+++ b/tabcmd/commands/user/create_site_users.py
@@ -40,7 +40,7 @@ class CreateSiteUsersCommand(UserCommand):
 
         UserCommand.validate_file_for_import(args.filename, logger, detailed=True, strict=args.require_all_valid)
 
-        logger.info(_("tabcmd.add.users.to_x").format(args.filename.name, creation_site))
+        logger.info(_("tabcmd.add.users.to_site").format(args.filename.name, creation_site))
         user_obj_list = UserCommand.get_users_from_file(args.filename, logger)
         logger.info(_("session.monitorjob.percent_complete").format(0))
         error_list = []
@@ -57,7 +57,7 @@ class CreateSiteUsersCommand(UserCommand):
             except TSC.ServerResponseError as e:
                 logger.debug(e)
                 if Errors.is_resource_conflict(e) and args.continue_if_exists:
-                    logger.debug(_("createsite.errors.site_name_already_exists").format(args.new_site_name))
+                    logger.debug(_("createsite.errors.site_name_already_exists").format(user_obj.name))
                 else:
                     number_of_errors += 1
                     logger.debug(number_of_errors)

--- a/tabcmd/commands/user/user_data.py
+++ b/tabcmd/commands/user/user_data.py
@@ -9,6 +9,7 @@ import tableauserverclient as TSC
 from tabcmd.commands.constants import Errors
 from tabcmd.commands.server import Server
 from tabcmd.execution.localize import _
+from tabcmd.execution.global_options import case_insensitive_string_type
 
 
 class Userdata:
@@ -58,8 +59,25 @@ CHOICES: List[List[str]] = [
     ["system", "site", "none", "no"],  # admin
     ["yes", "true", "1", "no", "false", "0"],  # publisher
     [],
-    [TSC.UserItem.Auth.SAML, TSC.UserItem.Auth.OpenID, TSC.UserItem.Auth.ServerDefault],  # auth
 ]
+
+site_roles = [
+    "ServerAdministrator",
+    "SiteAdministratorCreator",
+    "SiteAdministratorExplorer",
+    "SiteAdministrator",
+    "Creator",
+    "ExplorerCanPublish",
+    "Publisher",
+    "Explorer",
+    "Interactor",
+    "Viewer",
+    "Unlicensed",
+]
+
+AuthTypes = (
+    [TSC.UserItem.Auth.SAML, TSC.UserItem.Auth.OpenID, TSC.UserItem.Auth.ServerDefault, "TableauID", "Local"],
+)  # auth types
 
 
 # username, password, display_name, license, admin_level, publishing, email, auth type
@@ -71,15 +89,40 @@ class Column(IntEnum):
     ADMIN = 4
     PUBLISHER = 5
     EMAIL = 6
-    AUTH = 7
 
-    MAX = 7
+    MAX = 7  # number of columns
 
 
 class UserCommand(Server):
     """
     This class acts as a base class for user related group of commands
     """
+
+    @staticmethod
+    def set_role_arg(parser):
+        parser.add_argument(
+            "-r",
+            "--role",
+            choices=site_roles,
+            type=case_insensitive_string_type(site_roles),
+            help="Specifies a site role for all users in the .csv file. Possible roles: " + ", ".join(site_roles),
+            metavar="SITE_ROLE",
+        )
+        return parser
+
+    @staticmethod
+    def set_auth_arg(parser):
+        parser.add_argument(
+            "--auth-type",
+            metavar="TYPE",
+            choices=AuthTypes,
+            type=case_insensitive_string_type(AuthTypes),
+            # default="TableauID",  # default is Local for on-prem, TableauID for Online. Does the server apply the default?
+            help="Assigns the authentication type for all users in the CSV file. \
+    For Tableau Online, TYPE may be TableauID (default) or SAML. \
+    For Tableau Server, TYPE may be Local (default) or SAML.",
+        )
+        return parser
 
     # read the file containing usernames or user details and validate each line
     # log out any errors encountered

--- a/tabcmd/commands/user/user_data.py
+++ b/tabcmd/commands/user/user_data.py
@@ -75,9 +75,7 @@ site_roles = [
     "Unlicensed",
 ]
 
-AuthTypes = (
-    [TSC.UserItem.Auth.SAML, TSC.UserItem.Auth.OpenID, TSC.UserItem.Auth.ServerDefault, "TableauID", "Local"],
-)  # auth types
+auth_types = ["Local", TSC.UserItem.Auth.SAML, TSC.UserItem.Auth.OpenID, TSC.UserItem.Auth.ServerDefault, "TableauId"]
 
 
 # username, password, display_name, license, admin_level, publishing, email, auth type
@@ -115,8 +113,8 @@ class UserCommand(Server):
         parser.add_argument(
             "--auth-type",
             metavar="TYPE",
-            choices=AuthTypes,
-            type=case_insensitive_string_type(AuthTypes),
+            choices=auth_types,
+            type=case_insensitive_string_type(auth_types),
             # default="TableauID",  # default is Local for on-prem, TableauID for Online. Does the server apply the default?
             help="Assigns the authentication type for all users in the CSV file. \
     For Tableau Online, TYPE may be TableauID (default) or SAML. \

--- a/tabcmd/execution/global_options.py
+++ b/tabcmd/execution/global_options.py
@@ -25,6 +25,20 @@ BUT filename, username -> filename, username in command/parser
 
 """
 
+# argparse does case-sensitive comparisons of string inputs by default
+# I want the user to be able to enter e.g. "viewer" and have it accepted as "Viewer"
+# https://stackoverflow.com/questions/56838004/
+# case-insensitive-argparse-choices-without-losing-case-information-in-choices-lis
+def case_insensitive_string_type(choices):
+    def find_choice(choice):
+        for key, item in enumerate([choice.lower() for choice in choices]):
+            if choice.lower() == item:
+                return choices[key]
+        else:
+            return choice
+
+    return find_choice
+
 
 def set_parent_project_arg(parser):
     parser.add_argument("--parent-project-path", default=None, help="path of parent project")
@@ -65,33 +79,6 @@ def set_no_wait_option(parser):
     return parser
 
 
-site_roles = [
-    "ServerAdministrator",
-    "SiteAdministratorCreator",
-    "SiteAdministratorExplorer",
-    "SiteAdministrator",
-    "Creator",
-    "ExplorerCanPublish",
-    "Publisher",
-    "Explorer",
-    "Interactor",
-    "Viewer",
-    "Unlicensed",
-]
-
-
-def set_role_arg(parser):
-    parser.add_argument(
-        "-r",
-        "--role",
-        choices=list(map(lambda x: x.lower(), site_roles)),
-        type=str.lower,
-        help="Specifies a site role for all users in the .csv file. Possible roles: " + ", ".join(site_roles),
-        metavar="SITE_ROLE",
-    )
-    return parser
-
-
 def set_silent_option(parser):
     parser.add_argument(
         "--silent-progress", action="store_true", help="Do not display progress messages for the command."
@@ -118,10 +105,10 @@ def set_completeness_options(parser):
 
 
 # used in create/delete extract
-# docs don't say it, but --embedded-datasources and --include-all could be mutually exclusive
 def set_embedded_datasources_options(parser):
+    # one of these is required IFF we are using a workbook instead of datasource
     embedded_group = parser.add_mutually_exclusive_group()
-    embedded_group.add_argument(
+    embedded_group.add_argument(  # nargs?
         "--embedded-datasources",
         help="A space-separated list of embedded data source names within the target workbook.",
     )
@@ -189,10 +176,12 @@ def set_ds_xor_wb_options(parser):
 
 
 # pass arguments for either --datasource or --workbook
-def set_ds_xor_wb_args(parser):
+def set_ds_xor_wb_args(parser, url=False):
     target_type_group = parser.add_mutually_exclusive_group(required=True)
     target_type_group.add_argument("-d", "--datasource", help="The name of the target datasource.")
     target_type_group.add_argument("-w", "--workbook", help="The name of the target workbook.")
+    if url:
+        target_type_group.add_argument("--url", "-U", help=_("deleteextracts.options.url"))
     return parser
 
 
@@ -241,16 +230,17 @@ def set_common_site_args(parser):
         help="In MB, the amount of data that can be stored on the site.",
     )
 
+    encryption_modes = ["enforced", "enabled", "disabled"]
     parser.add_argument(
         "--extract-encryption-mode",
-        choices=["enforced", "enabled", "disabled"],
+        choices=encryption_modes,
+        type=case_insensitive_string_type(encryption_modes),
         help="The extract encryption mode for the site can be enforced, enabled or disabled. ",
     )
 
     parser.add_argument(
         "--run-now-enabled",
         choices=["true", "false"],
-        type=str.lower,
         help="Allow or deny users from running extract refreshes, flows, or schedules manually.",
     )
     return parser
@@ -332,6 +322,7 @@ def set_publish_args(parser):
 
     parser.add_argument("--use-tableau-bridge", action="store_true", help="Refresh datasource through Tableau Bridge")
 
+
 def set_overwrite_option(parser):
     append_group = parser.add_mutually_exclusive_group()
     append_group.add_argument(
@@ -405,11 +396,14 @@ def set_target_users_arg(parser):
 
 
 # sync-group
+license_modes = ["on-login", "on-sync"]
+
+
 def set_update_group_args(parser):
     parser.add_argument(
         "--grant-license-mode",
-        choices=["on-login", "on-sync"],
-        type=str.lower,
+        choices=license_modes,
+        type=case_insensitive_string_type(license_modes),
         help="Specifies whether a role should be granted on sign in. ",
     )
     parser.add_argument(

--- a/tests/commands/test_run_commands.py
+++ b/tests/commands/test_run_commands.py
@@ -359,6 +359,8 @@ class RunCommandsTest(unittest.TestCase):
         mock_args.filename = RunCommandsTest._set_up_file()
         mock_args.require_all_valid = False
         mock_args.site_name = None
+        mock_args.role = "Viewer"
+        mock_args.auth_type = "SAML"
         create_site_users.CreateSiteUsersCommand.run_command(mock_args)
         mock_session.assert_called()
 


### PR DESCRIPTION
Fixes https://github.com/tableau/tabcmd/issues/197

There is an underlying bug in tsc that doesn't accept all values of auth-type. That will be fixed and once the new version of tsc is being used, it will work here too.

example:
tabcmd createsiteusers "tests\assets\detailed_users.csv" --role Viewer
tabcmd createsiteusers "tests\assets\detailed_users.csv" --auth-type SAML