### PR TITLE
Jac/user agent

### DIFF
--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -12,6 +12,8 @@ from tabcmd.commands.constants import Errors
 from tabcmd.execution.localize import _
 from tabcmd.execution.logger_config import log
 
+from typing import Dict, Any
+
 
 class Session:
     """
@@ -153,7 +155,7 @@ class Session:
         # args still to be handled here:
         # proxy, --no-proxy,
         # cert
-        http_options = {"headers": {"User-Agent": "Tabcmd" + version}}
+        http_options: Dict[str, Any] = {"headers": {"User-Agent": "Tabcmd" + version}}
         if self.no_certcheck:
             http_options["verify"] = False
             urllib3.disable_warnings(category=InsecureRequestWarning)

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -5,6 +5,7 @@ import os
 import requests
 import tableauserverclient as TSC
 import urllib3
+from tabcmd.execution.parent_parser import ParentParser
 from urllib3.exceptions import InsecureRequestWarning
 
 from tabcmd.commands.constants import Errors
@@ -152,7 +153,7 @@ class Session:
         # args still to be handled here:
         # proxy, --no-proxy,
         # cert
-        http_options = {}
+        http_options = {"User-Agent": ParentParser.get_version()}
         if self.no_certcheck:
             http_options["verify"] = False
             urllib3.disable_warnings(category=InsecureRequestWarning)

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -155,7 +155,7 @@ class Session:
         # args still to be handled here:
         # proxy, --no-proxy,
         # cert
-        http_options: Dict[str, Any] = {"headers": {"User-Agent": "Tabcmd" + version}}
+        http_options: Dict[str, Any] = {"headers": {"User-Agent": "Tabcmd/{}".format(version)}}
         if self.no_certcheck:
             http_options["verify"] = False
             urllib3.disable_warnings(category=InsecureRequestWarning)

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -5,9 +5,9 @@ import os
 import requests
 import tableauserverclient as TSC
 import urllib3
-from tabcmd.execution.parent_parser import ParentParser
 from urllib3.exceptions import InsecureRequestWarning
 
+from tabcmd.version import version
 from tabcmd.commands.constants import Errors
 from tabcmd.execution.localize import _
 from tabcmd.execution.logger_config import log
@@ -153,7 +153,7 @@ class Session:
         # args still to be handled here:
         # proxy, --no-proxy,
         # cert
-        http_options = {"User-Agent": ParentParser.get_version()}
+        http_options = {"headers": {"User-Agent": "Tabcmd" + version}}
         if self.no_certcheck:
             http_options["verify"] = False
             urllib3.disable_warnings(category=InsecureRequestWarning)

--- a/tabcmd/execution/parent_parser.py
+++ b/tabcmd/execution/parent_parser.py
@@ -154,6 +154,10 @@ class ParentParser:
     """Parser that will be inherited by all commands. Contains
     authentication and logging level setting"""
 
+    @staticmethod
+    def get_version(self):
+        return version
+
     def __init__(self):
         self.global_options = parent_parser_with_global_options()
         self.root = argparse.ArgumentParser(

--- a/tabcmd/execution/parent_parser.py
+++ b/tabcmd/execution/parent_parser.py
@@ -1,21 +1,9 @@
 import argparse
-import logging
 
 from .localize import _
 from .logger_config import log
 from .map_of_commands import CommandsMap
-
-
-# when we drop python 3.8, this could be replaced with this lighter weight option
-# from importlib.metadata import version, PackageNotFoundError
-from pkg_resources import get_distribution, DistributionNotFound
-
-try:
-    version = get_distribution("tabcmd").version
-except DistributionNotFound:
-    version = "2.x.unknown"
-    pass
-
+from tabcmd.version import version
 
 """
 Note: output order is influenced first by grouping, then by order they are added in here
@@ -153,10 +141,6 @@ class ParentParser:
     # Ref https://docs.python.org/3/library/argparse.html
     """Parser that will be inherited by all commands. Contains
     authentication and logging level setting"""
-
-    @staticmethod
-    def get_version(self):
-        return version
 
     def __init__(self):
         self.global_options = parent_parser_with_global_options()

--- a/tabcmd/version.py
+++ b/tabcmd/version.py
@@ -1,0 +1,9 @@
+# when we drop python 3.8, this could be replaced with this lighter weight option
+# from importlib.metadata import version, PackageNotFoundError
+from pkg_resources import get_distribution, DistributionNotFound
+
+try:
+    version = get_distribution("tabcmd").version
+except DistributionNotFound:
+    version = "2.0.0"
+    pass

--- a/tests/e2e/online_tests.py
+++ b/tests/e2e/online_tests.py
@@ -129,12 +129,6 @@ class OnlineCommandTest(unittest.TestCase):
         arguments = [command, server_file]
         _test_command(arguments)
 
-    def _get_datasource(self, server_file):
-        command = "get"
-        server_file = "/datasources/" + server_file
-        arguments = [command, server_file]
-        _test_command(arguments)
-
     def _create_extract(self, wb_name):
         command = "createextracts"
         arguments = [command, "-w", wb_name, "--encrypt"]


### PR DESCRIPTION
Set the user agent of the new TSC.Server object, including the version.
This will not show up in requests until we use the newest version of TSC. 