### PR TITLE
Always log version

### DIFF
--- a/tabcmd/execution/tabcmd_controller.py
+++ b/tabcmd/execution/tabcmd_controller.py
@@ -5,6 +5,8 @@ from .localize import set_client_locale
 from .logger_config import log
 from .parent_parser import ParentParser
 
+from tabcmd.version import version
+
 
 class TabcmdController:
     @staticmethod
@@ -27,6 +29,7 @@ class TabcmdController:
             print("logging:", namespace.logging_level)
 
         logger = log(__name__, namespace.logging_level or logging.INFO)
+        logger.info("Tabcmd {}".format(version))
         if (hasattr("namespace", "password") or hasattr("namespace", "token_value")) and hasattr("namespace", "func"):
             # don't print whole namespace because it has secrets
             logger.debug(namespace.func)


### PR DESCRIPTION
When people ask for help they usually show default logs and don't know what version they have. This will make it easier to debug.