### PR TITLE
Jac/parse publish options

### DIFF
--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -249,7 +249,7 @@ class Session:
                 self.username = self.tableau_server.users.get_by_id(self.user_id).name
             self.logger.info(_("common.output.succeeded"))
         except Exception as e:
-            Errors.exit_with_error(self.logger, e)
+            Errors.exit_with_error(self.logger, exception=e)
         self.logger.debug("Signed into {0}{1} as {2}".format(self.server_url, self.site_name, self.username))
         return self.tableau_server
 

--- a/tabcmd/commands/constants.py
+++ b/tabcmd/commands/constants.py
@@ -1,5 +1,6 @@
 import inspect
 import sys
+from typing import Optional
 
 import tableauserverclient
 
@@ -56,7 +57,7 @@ class Errors:
             logger.info("Error printing stack trace:", e)
 
     @staticmethod
-    def exit_with_error(logger, message=None, exception: Exception = None):
+    def exit_with_error(logger, message: Optional[str] = None, exception: Optional[Exception] = None):
         try:
             if message and not exception:
                 logger.error(message)

--- a/tabcmd/commands/constants.py
+++ b/tabcmd/commands/constants.py
@@ -56,7 +56,7 @@ class Errors:
             logger.info("Error printing stack trace:", e)
 
     @staticmethod
-    def exit_with_error(logger, message=None, exception:Exception=None):
+    def exit_with_error(logger, message=None, exception: Exception = None):
         try:
             if message and not exception:
                 logger.error(message)

--- a/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
@@ -28,7 +28,7 @@ class DatasourcesAndWorkbooks(Server):
             logger.debug(req_option.get_query_params())
             matching_views, paging = server.views.get(req_option)
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)
         if len(matching_views) < 1:
             Errors.exit_with_error(logger, message=_("errors.xmlapi.not_found"))
         return matching_views[0]
@@ -42,7 +42,7 @@ class DatasourcesAndWorkbooks(Server):
             logger.debug(req_option.get_query_params())
             matching_workbooks, paging = server.workbooks.get(req_option)
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)
         if len(matching_workbooks) < 1:
             Errors.exit_with_error(logger, message=_("dataalerts.failure.error.workbookNotFound"))
         return matching_workbooks[0]
@@ -56,7 +56,7 @@ class DatasourcesAndWorkbooks(Server):
             logger.debug(req_option.get_query_params())
             matching_datasources, paging = server.datasources.get(req_option)
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)
         if len(matching_datasources) < 1:
             Errors.exit_with_error(logger, message=_("dataalerts.failure.error.datasourceNotFound"))
         return matching_datasources[0]

--- a/tabcmd/commands/datasources_and_workbooks/export_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/export_command.py
@@ -54,7 +54,9 @@ class ExportCommand(DatasourcesAndWorkbooks):
             help="Set the page size of the exported PDF",
         )
 
-        group.add_argument("--width", default=800, help="[Not Yet Implemented] Set the width of the image in pixels. Default is 800 px")
+        group.add_argument(
+            "--width", default=800, help="[Not Yet Implemented] Set the width of the image in pixels. Default is 800 px"
+        )
         group.add_argument("--filename", "-f", help="filename to store the exported data")
         group.add_argument("--height", default=600, help=_("export.options.height"))
         group.add_argument(

--- a/tabcmd/commands/datasources_and_workbooks/export_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/export_command.py
@@ -54,7 +54,7 @@ class ExportCommand(DatasourcesAndWorkbooks):
             help="Set the page size of the exported PDF",
         )
 
-        group.add_argument("--width", default=800, help="Set the width of the image in pixels. Default is 800 px")
+        group.add_argument("--width", default=800, help="[Not Yet Implemented] Set the width of the image in pixels. Default is 800 px")
         group.add_argument("--filename", "-f", help="filename to store the exported data")
         group.add_argument("--height", default=600, help=_("export.options.height"))
         group.add_argument(

--- a/tabcmd/commands/datasources_and_workbooks/publish_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/publish_command.py
@@ -75,8 +75,7 @@ class PublishCommand(DatasourcesAndWorkbooks):
             if args.thumbnail_username and args.thumbnail_group:
                 raise AttributeError("Cannot specify both a user and group for thumbnails.")
 
-            new_workbook = TSC.WorkbookItem(
-                project_id, name=args.name, show_tabs=args.tabbed)
+            new_workbook = TSC.WorkbookItem(project_id, name=args.name, show_tabs=args.tabbed)
             try:
                 new_workbook = server.workbooks.publish(
                     new_workbook,
@@ -87,7 +86,6 @@ class PublishCommand(DatasourcesAndWorkbooks):
                     connection_credentials=creds,
                     as_job=False,
                     skip_connection_check=False,
-
                 )
             except IOError as ioe:
                 Errors.exit_with_error(logger, ioe)

--- a/tabcmd/commands/datasources_and_workbooks/publish_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/publish_command.py
@@ -101,7 +101,6 @@ class PublishCommand(DatasourcesAndWorkbooks):
                 Errors.exit_with_error(logger, exception=exc)
             logger.info(_("publish.success") + "\n{}".format(new_datasource.webpage_url))
 
-
     # todo write tests for this method
     @staticmethod
     def get_publish_mode(args, logger):

--- a/tabcmd/commands/user/user_data.py
+++ b/tabcmd/commands/user/user_data.py
@@ -260,7 +260,7 @@ class UserCommand(Server):
         try:
             group = UserCommand.find_group(logger, server, args.name)
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)
 
         n_users_handled: int = 0
         number_of_errors: int = 0

--- a/tabcmd/execution/global_options.py
+++ b/tabcmd/execution/global_options.py
@@ -126,7 +126,7 @@ def set_encryption_option(parser):
         "--encrypt",
         dest="encrypt",
         action="store_true",  # set to true IF user passes in option --encrypt
-        help="Encrypt the newly created extract. [N/a on Tableau Cloud: extracts are always encrypted]",
+        help="Encrypt the newly created extract. [N/a on Tableau Cloud: extract encryption is controlled by Site Admin]",
     )
     return parser
 
@@ -306,7 +306,7 @@ def set_publish_args(parser):
         "--encrypt-extracts",
         action="store_true",
         help="Encrypt extracts in the workbook, datasource, or extract being published to the server. "
-             "[N/a on Tableau Cloud: extracts are always encrypted]",
+             "[N/a on Tableau Cloud: extract encryption is controlled by Site Admin]",
     )
 
     # These two only apply for a workbook, not a datasource
@@ -372,12 +372,12 @@ def set_calculations_options(parser):
     calc_group.add_argument(
         "--addcalculations",
         action="store_true",
-        help="DEPRECATED [has no effect] Add precalculated data operations in the extract data source.",
+        help="[Not implemented] Add precalculated data operations in the extract data source.",
     )
     calc_group.add_argument(
         "--removecalculations",
         action="store_true",
-        help="DEPRECATED [has no effect] Remove precalculated data in the extract data source.",
+        help="[Not implemented] Remove precalculated data in the extract data source.",
     )
     return calc_group
 

--- a/tabcmd/execution/global_options.py
+++ b/tabcmd/execution/global_options.py
@@ -311,9 +311,20 @@ def set_publish_args(parser):
         action="store_true",
         help="Encrypt extracts in the workbook, datasource, or extract being published to the server",
     )
+
+    parser.add_argument("--oauth-username", help="The email address of a preconfigured OAuth connection")
+    parser.add_argument("--save-oauth", action="store_true", help="Save embedded OAuth credentials in the datasource")
+
+    # These two only apply for a workbook, not a datasource
     thumbnails = parser.add_mutually_exclusive_group()
-    thumbnails.add_argument("--thumbnail-username", help="Not yet implemented")
-    thumbnails.add_argument("--thumbnail-group", help="Not yet implemented")  # not implemented in the REST API
+    thumbnails.add_argument(
+        "--thumbnail-username",
+        help="If the workbook contains user filters, the thumbnails will be generated based on what the "
+             "specified user can see. Cannot be specified when --thumbnail-group option is set.")
+    thumbnails.add_argument(
+        "--thumbnail-group",
+        help="If the workbook contains user filters, the thumbnails will be generated based on what the "
+             "specified group can see. Cannot be specified when --thumbnail-usernameoption is set.")
 
     parser.add_argument("--use-tableau-bridge", action="store_true", help="Refresh datasource through Tableau Bridge")
 

--- a/tabcmd/execution/global_options.py
+++ b/tabcmd/execution/global_options.py
@@ -126,7 +126,7 @@ def set_encryption_option(parser):
         "--encrypt",
         dest="encrypt",
         action="store_true",  # set to true IF user passes in option --encrypt
-        help="Encrypt the newly created extract.",
+        help="Encrypt the newly created extract. [N/a on Tableau Cloud: extracts are always encrypted]",
     )
     return parser
 
@@ -230,7 +230,8 @@ def set_common_site_args(parser):
         "--extract-encryption-mode",
         choices=encryption_modes,
         type=case_insensitive_string_type(encryption_modes),
-        help="The extract encryption mode for the site can be enforced, enabled or disabled. ",
+        help="The extract encryption mode for the site can be enforced, enabled or disabled. "
+             "[N/a on Tableau Cloud: encryption mode is always enforced] ",
     )
 
     parser.add_argument(
@@ -275,8 +276,6 @@ def set_filename_arg(parser, description=_("get.options.file")):
 def set_publish_args(parser):
     parser.add_argument("-n", "--name", help="Name to publish the new datasource or workbook by.")
 
-    set_overwrite_option(parser)
-
     creds = parser.add_mutually_exclusive_group()
     creds.add_argument("--oauth-username", help="The email address of a preconfigured OAuth connection")
     creds.add_argument(
@@ -301,19 +300,14 @@ def set_publish_args(parser):
         help="When a workbook with tabbed views is published, each sheet becomes a tab that viewers can use to \
         navigate through the workbook",
     )
-    parser.add_argument(
-        "--replace", action="store_true", help="Use the extract file to replace the existing data source."
-    )
-    parser.add_argument("--disable-uploader", action="store_true", help="Disable the incremental file uploader.")
-    parser.add_argument("--restart", help="Restart the file upload.")
+    parser.add_argument("--disable-uploader", action="store_true", help="[DEPRECATED - has no effect] Disable the incremental file uploader.")
+    parser.add_argument("--restart", help="[DEPRECATED - has no effect] Restart the file upload.")
     parser.add_argument(
         "--encrypt-extracts",
         action="store_true",
-        help="Encrypt extracts in the workbook, datasource, or extract being published to the server",
+        help="Encrypt extracts in the workbook, datasource, or extract being published to the server. "
+             "[N/a on Tableau Cloud: extracts are always encrypted]",
     )
-
-    parser.add_argument("--oauth-username", help="The email address of a preconfigured OAuth connection")
-    parser.add_argument("--save-oauth", action="store_true", help="Save embedded OAuth credentials in the datasource")
 
     # These two only apply for a workbook, not a datasource
     thumbnails = parser.add_mutually_exclusive_group()
@@ -323,24 +317,40 @@ def set_publish_args(parser):
              "specified user can see. Cannot be specified when --thumbnail-group option is set.")
     thumbnails.add_argument(
         "--thumbnail-group",
-        help="If the workbook contains user filters, the thumbnails will be generated based on what the "
-             "specified group can see. Cannot be specified when --thumbnail-usernameoption is set.")
+        help="[Not yet implemented] If the workbook contains user filters, the thumbnails will be generated based on what the "
+             "specified group can see. Cannot be specified when --thumbnail-username option is set.")
 
     parser.add_argument("--use-tableau-bridge", action="store_true", help="Refresh datasource through Tableau Bridge")
 
 
-def set_overwrite_option(parser):
+# these two are used to publish an extract to an existing data source
+def set_append_replace_option(parser):
     append_group = parser.add_mutually_exclusive_group()
-    append_group.add_argument(
-        "-o",
-        "--overwrite",
-        action="store_true",
-        help="Overwrites the workbook, data source, or data extract if it already exists on the server.",
-    )
     append_group.add_argument(
         "--append",
         action="store_true",
-        help="Append the extract file to the existing data source.",
+        help="Set to true to append the data being published to an existing data source that has the same name. "
+             "The default behavior is to fail if the data source already exists. "
+             "If append is set to true but the data source doesn't already exist, the operation fails."
+    )
+
+    # what's the difference between this and 'overwrite'?
+    # This is meant for when a) the local file is an extract b) the server item is an existing data source
+    append_group.add_argument(
+        "--replace",
+        action="store_true",
+        help="Use the extract file being published to replace data in the existing data source. The default "
+             "behavior is to fail if the item already exists."
+    )
+
+# this is meant to be like replacing like
+def set_overwrite_option(parser):
+    parser.add_argument(
+        "-o",
+        "--overwrite",
+        action="store_true",
+        help="Overwrites the workbook, data source, or data extract if it already exists on the server. The default "
+             "behavior is to fail if the item already exists."
     )
 
 

--- a/tabcmd/execution/global_options.py
+++ b/tabcmd/execution/global_options.py
@@ -231,7 +231,7 @@ def set_common_site_args(parser):
         choices=encryption_modes,
         type=case_insensitive_string_type(encryption_modes),
         help="The extract encryption mode for the site can be enforced, enabled or disabled. "
-             "[N/a on Tableau Cloud: encryption mode is always enforced] ",
+        "[N/a on Tableau Cloud: encryption mode is always enforced] ",
     )
 
     parser.add_argument(
@@ -300,13 +300,17 @@ def set_publish_args(parser):
         help="When a workbook with tabbed views is published, each sheet becomes a tab that viewers can use to \
         navigate through the workbook",
     )
-    parser.add_argument("--disable-uploader", action="store_true", help="[DEPRECATED - has no effect] Disable the incremental file uploader.")
+    parser.add_argument(
+        "--disable-uploader",
+        action="store_true",
+        help="[DEPRECATED - has no effect] Disable the incremental file uploader.",
+    )
     parser.add_argument("--restart", help="[DEPRECATED - has no effect] Restart the file upload.")
     parser.add_argument(
         "--encrypt-extracts",
         action="store_true",
         help="Encrypt extracts in the workbook, datasource, or extract being published to the server. "
-             "[N/a on Tableau Cloud: extract encryption is controlled by Site Admin]",
+        "[N/a on Tableau Cloud: extract encryption is controlled by Site Admin]",
     )
 
     # These two only apply for a workbook, not a datasource
@@ -314,11 +318,13 @@ def set_publish_args(parser):
     thumbnails.add_argument(
         "--thumbnail-username",
         help="If the workbook contains user filters, the thumbnails will be generated based on what the "
-             "specified user can see. Cannot be specified when --thumbnail-group option is set.")
+        "specified user can see. Cannot be specified when --thumbnail-group option is set.",
+    )
     thumbnails.add_argument(
         "--thumbnail-group",
         help="[Not yet implemented] If the workbook contains user filters, the thumbnails will be generated based on what the "
-             "specified group can see. Cannot be specified when --thumbnail-username option is set.")
+        "specified group can see. Cannot be specified when --thumbnail-username option is set.",
+    )
 
     parser.add_argument("--use-tableau-bridge", action="store_true", help="Refresh datasource through Tableau Bridge")
 
@@ -330,8 +336,8 @@ def set_append_replace_option(parser):
         "--append",
         action="store_true",
         help="Set to true to append the data being published to an existing data source that has the same name. "
-             "The default behavior is to fail if the data source already exists. "
-             "If append is set to true but the data source doesn't already exist, the operation fails."
+        "The default behavior is to fail if the data source already exists. "
+        "If append is set to true but the data source doesn't already exist, the operation fails.",
     )
 
     # what's the difference between this and 'overwrite'?
@@ -340,8 +346,9 @@ def set_append_replace_option(parser):
         "--replace",
         action="store_true",
         help="Use the extract file being published to replace data in the existing data source. The default "
-             "behavior is to fail if the item already exists."
+        "behavior is to fail if the item already exists.",
     )
+
 
 # this is meant to be like replacing like
 def set_overwrite_option(parser):
@@ -350,7 +357,7 @@ def set_overwrite_option(parser):
         "--overwrite",
         action="store_true",
         help="Overwrites the workbook, data source, or data extract if it already exists on the server. The default "
-             "behavior is to fail if the item already exists."
+        "behavior is to fail if the item already exists.",
     )
 
 

--- a/tabcmd/execution/parent_parser.py
+++ b/tabcmd/execution/parent_parser.py
@@ -101,7 +101,7 @@ def parent_parser_with_global_options():
     parser.add_argument(
         "--continue-if-exists",
         action="store_true",  # default behavior matches old tabcmd
-        help=strings[9],
+        help=strings[9],  # kind of equivalent to 'overwrite' in the publish command
     )
 
     parser.add_argument(

--- a/tests/commands/test_run_commands.py
+++ b/tests/commands/test_run_commands.py
@@ -148,6 +148,10 @@ class RunCommandsTest(unittest.TestCase):
         mock_args.tabbed = True
         mock_args.db_username = None
         mock_args.oauth_username = None
+        mock_args.append = False
+        mock_args.replace = False
+        mock_args.thumbnail_username = None
+        mock_args.thumbnail_group = None
         mock_server.projects = getter
         publish_command.PublishCommand.run_command(mock_args)
         mock_session.assert_called()

--- a/tests/parsers/test_parser_publish.py
+++ b/tests/parsers/test_parser_publish.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import skip
 
 from tabcmd.commands.datasources_and_workbooks.publish_command import PublishCommand
 from .common_setup import *
@@ -38,3 +39,69 @@ class PublishParserTest(unittest.TestCase):
         ]
         args = self.parser_under_test.parse_args(mock_args)
         assert args.save_db_password is True, args
+
+    def test_publish_parser_save_oauth(self):
+        mock_args = [
+            commandname,
+            "filename.twbx",
+            "--oauth-username",
+            "user",
+            "--save-oauth",
+        ]
+        args = self.parser_under_test.parse_args(mock_args)
+        assert args.save_oauth is True, args
+        assert args.oauth_username == "user", args
+
+
+    def test_publish_parser_thumbnails(self):
+        mock_args = [commandname, "filename.twbx", "--thumbnail-username"] # no value for thumbnail-user
+        with self.assertRaises(SystemExit):
+            args = self.parser_under_test.parse_args(mock_args)
+
+        mock_args = [commandname, "filename.twbx", "--thumbnail-username", "goofy"]
+        args = self.parser_under_test.parse_args(mock_args)
+        assert args.thumbnail_username == "goofy", args
+
+    @skip("Not yet implemented")
+    def test_publish_parser_thumbnail_group(self):
+        mock_args = [commandname, "filename.twbx", "--thumbnail-group", "goofy"]
+        args = self.parser_under_test.parse_args(mock_args)
+        assert args.thumbnail_group == "goofy", args
+
+    """
+    append | replace | overwrite -> result
+    --------
+    true   | F/empty | F/empty   -> append
+    true   | F/empty | true      -> ERROR
+    true   | true    | F/empty   -> ERROR
+    .... basically, replace == overwrite, append != r/o
+    """
+    def test_publish_parser_append_options(self):
+        mock_args = [commandname, "filename.twbx", "--append"]
+        args = self.parser_under_test.parse_args(mock_args)
+
+    def test_publish_parser_replace_and_append(self):
+        mock_args = [commandname, "filename.twbx", "--append", "--replace"]
+        with self.assertRaises(SystemExit):
+            args = self.parser_under_test.parse_args(mock_args)
+
+    def test_publish_parser_replace_options(self):
+        mock_args = [commandname, "filename.twbx", "--overwrite"]
+        args = self.parser_under_test.parse_args(mock_args)
+
+        mock_args = [commandname, "filename.twbx", "--replace"]
+        args = self.parser_under_test.parse_args(mock_args)
+
+        mock_args = [commandname, "filename.twbx", "--replace", "--overwrite"]
+        args = self.parser_under_test.parse_args(mock_args)
+
+    def test_publish_parser_deprecated_options(self):
+        # does nothing in new tabcmd, but shouldn't break anything
+        mock_args = [commandname, "filename.twbx", "--disable-uploader"]
+        args = self.parser_under_test.parse_args(mock_args)
+        mock_args = [commandname, "filename.twbx", "--restart", "argument"]
+        args = self.parser_under_test.parse_args(mock_args)
+
+    def test_publish_parser_use_bridge_option(self):
+        mock_args = [commandname, "filename.twbx","--use-tableau-bridge"]
+        args = self.parser_under_test.parse_args(mock_args)

--- a/tests/parsers/test_parser_publish.py
+++ b/tests/parsers/test_parser_publish.py
@@ -52,9 +52,8 @@ class PublishParserTest(unittest.TestCase):
         assert args.save_oauth is True, args
         assert args.oauth_username == "user", args
 
-
     def test_publish_parser_thumbnails(self):
-        mock_args = [commandname, "filename.twbx", "--thumbnail-username"] # no value for thumbnail-user
+        mock_args = [commandname, "filename.twbx", "--thumbnail-username"]  # no value for thumbnail-user
         with self.assertRaises(SystemExit):
             args = self.parser_under_test.parse_args(mock_args)
 
@@ -76,6 +75,7 @@ class PublishParserTest(unittest.TestCase):
     true   | true    | F/empty   -> ERROR
     .... basically, replace == overwrite, append != r/o
     """
+
     def test_publish_parser_append_options(self):
         mock_args = [commandname, "filename.twbx", "--append"]
         args = self.parser_under_test.parse_args(mock_args)
@@ -103,5 +103,5 @@ class PublishParserTest(unittest.TestCase):
         args = self.parser_under_test.parse_args(mock_args)
 
     def test_publish_parser_use_bridge_option(self):
-        mock_args = [commandname, "filename.twbx","--use-tableau-bridge"]
+        mock_args = [commandname, "filename.twbx", "--use-tableau-bridge"]
         args = self.parser_under_test.parse_args(mock_args)


### PR DESCRIPTION
Added --replace, --append and --overwrite options for publishing to the **parser**, but they are not yet all **implemented**  in the API and tsc.
Also gave more detailed help messages for extract encryption and thumbnail publishing options.

example for 'append':
_c:\dev\tabcmd2>python -m tabcmd publish tests\assets\SampleDS.tds --name my-second-drawing  --append
....
Succeeded
Publishing ''tests\assets\SampleDS.tds'' to the server. This could take several minutes...
        400054: Bad Request
                Only a '.hyper' or '.tde' file can be appended to a datasource.
Exiting..._
