### PR TITLE
freeze tsc dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "types-mock",
     "types-requests",
     "types-setuptools",
-    "tableauserverclient==0.23",
+    "tableauserverclient==0.25",
     "urllib3>=1.24.3,<2.0",
 ]
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "types-mock",
     "types-requests",
     "types-setuptools",
-    "tableauserverclient>=0.23",
+    "tableauserverclient==0.23",
     "urllib3>=1.24.3,<2.0",
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
should fix embedding pipeline, which was pulling in new version 0.26 of tsc