### PR TITLE
freeze tsc dependency (#248)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "types-mock",
     "types-requests",
     "types-setuptools",
-    "tableauserverclient>=0.23",
+    "tableauserverclient==0.25",
     "urllib3>=1.24.3,<2.0",
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
* freeze tsc dependency to 0.25

(cherry picked from commit fc992e4a8b4e82e8d5034fe6db8f8b21e5a9e4bb)
main and development need to be reconciled, I don't want to block this fix on it. 