### PR TITLE
Handle https proxy values

### DIFF
--- a/tabcmd/commands/constants.py
+++ b/tabcmd/commands/constants.py
@@ -58,23 +58,23 @@ class Errors:
 
     @staticmethod
     def exit_with_error(logger, message: Optional[str] = None, exception: Optional[Exception] = None):
+        suggest_logs_message = "Exiting with error...\nSee logs for more information."
         try:
             if message and not exception:
                 logger.error(message)
                 Errors.log_stack(logger)
             elif exception:
                 if message:
-                    logger.info("Error message: " + message)
+                    logger.info("\nError message: " + message)
                 Errors.check_common_error_codes_and_explain(logger, exception)
             else:
                 logger.info("No exception or message provided")
 
         except Exception as exc:
-            print(sys.stderr, "Error during log call from exception - {} {}".format(exc.__class__, message))
-        try:
-            logger.info("Exiting...")
-        except Exception:
-            print(sys.stderr, "Exiting...")
+            print("Error during log call from exception - {} {}".format(exc.__class__, message))
+
+        print("")
+        print(suggest_logs_message)
         sys.exit(1)
 
     @staticmethod
@@ -90,7 +90,10 @@ class Errors:
             # session.renew_session()
             return
         if exception.__class__ == tableauserverclient.ServerResponseError:
+            logger.debug("Server response error")
 
             logger.error(exception)
         else:
-            logger.exception(exception)
+            # logger.exception prints a really long ugly stack, generally not useful to users. 
+            # Should print that to the log, but not console.
+            logger.error(exception)

--- a/tabcmd/execution/parent_parser.py
+++ b/tabcmd/execution/parent_parser.py
@@ -202,7 +202,7 @@ strings = [
     "{<command> [command args]}",  # 5
     "Tableau Server Command Line Utility",  # 6
     "Show version information and exit.",  # 7
-    "Use the specified logging level. The default level is INFO.",  # 8
+    "Use the specified logging level. The default level is INFO. Logs are stored at {user}/AppData/Local/Tableau/Tabcmd/ or ~/.tableau/tabcmd/",  # 8
     "Treat resource conflicts as item creation success e.g project already exists",  # 9
     "Set the language to use. Exported data will be returned in this lang/locale.\n \
         If not set, the client will use your computer locale, and the server will use \

--- a/tests/commands/test_session.py
+++ b/tests/commands/test_session.py
@@ -420,8 +420,8 @@ class ConnectionOptionsTest(unittest.TestCase):
     def test_user_agent(self):
         mock_session = Session()
         mock_session.server_url = "fakehost"
-        connection = mock_session._open_connection_with_opts()
-        assert connection._http_options["headers"]["User-Agent"].startswith("Tabcmd/")
+        connection = mock_session._set_connection_options()
+        assert connection["headers"]["User-Agent"].startswith("Tabcmd/")
 
     def test_no_certcheck(self):
         mock_session = Session()
@@ -429,8 +429,8 @@ class ConnectionOptionsTest(unittest.TestCase):
         mock_session.no_certcheck = True
         mock_session.site_id = "s"
         mock_session.user_id = "u"
-        connection = mock_session._open_connection_with_opts()
-        assert connection._http_options["verify"] == False
+        connection = mock_session._set_connection_options()
+        assert connection["verify"] == False
 
     def test_cert(self):
         mock_session = Session()
@@ -438,17 +438,38 @@ class ConnectionOptionsTest(unittest.TestCase):
         mock_session.site_id = "s"
         mock_session.user_id = "u"
         mock_session.certificate = "my-cert-info"
-        connection = mock_session._open_connection_with_opts()
-        assert connection._http_options["cert"] == mock_session.certificate
+        connection = mock_session._set_connection_options()
+        assert connection["cert"] == mock_session.certificate
 
-    def test_proxy_stuff(self):
+    def test_proxy_http(self):
         mock_session = Session()
         mock_session.server_url = "fakehost"
         mock_session.site_id = "s"
         mock_session.user_id = "u"
         mock_session.proxy = "proxy:port"
-        connection = mock_session._open_connection_with_opts()
-        assert connection._http_options["proxies"] == {"http": mock_session.proxy}
+        connection = mock_session._set_connection_options()
+        fixed_proxy = "http://proxy:port"
+        assert connection["proxies"] == {"http": mock_session.proxy}
+        assert fixed_proxy == mock_session.proxy
+
+    def test_proxy_https(self):
+        mock_session = Session()
+        mock_session.server_url = "fakehost"
+        mock_session.site_id = "s"
+        mock_session.user_id = "u"
+        mock_session.proxy = "https://proxy:port"
+        connection = mock_session._set_connection_options()
+        assert connection["proxies"] == {"https": mock_session.proxy}
+
+    def test_no_proxy(self):        
+        mock_session = Session()
+        mock_session.server_url = "fakehost"
+        mock_session.site_id = "s"
+        mock_session.user_id = "u"
+        mock_session.no_proxy = True
+        connection = mock_session._set_connection_options()
+        assert connection["proxies"] == None
+
 
     def test_timeout(self):
         mock_session = Session()
@@ -456,9 +477,18 @@ class ConnectionOptionsTest(unittest.TestCase):
         mock_session.site_id = "s"
         mock_session.user_id = "u"
         mock_session.timeout = 10
-        connection = mock_session._open_connection_with_opts()
-        assert connection._http_options["timeout"] == 10
+        connection = mock_session._set_connection_options()
+        assert connection["timeout"] == 10
 
+
+    def test_setting_options_on_connection(self):
+        mock_session = Session()
+        mock_session.server_url = "fakehost"
+        mock_session.site_id = "s"
+        mock_session.user_id = "u"
+        mock_session.timeout = 10
+        connection = mock_session._open_connection_with_opts()
+        assert connection.http_options["timeout"] == 10
 
 """
 class CookieTests(unittest.TestCase):


### PR DESCRIPTION
We were assuming that any proxy value given would be a valid http URL. Updated this so that we check if it is https and pass it to the correct protocol handler if so, and we check  the url begins with a protocol and adds 'http' if not.

Updated logging to remove the full stack trace, which is pretty ugly and unhelpful in the case of connectivity errors where the first line is usually the meaningful one. Not sure if this will be the best decision in all scenarios - should probably add it back when logging at debug level?