### PR TITLE
fix filepath handling in Get command

### DIFF
--- a/tabcmd/commands/datasources_and_workbooks/get_url_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/get_url_command.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 
 import tableauserverclient as TSC
 from tableauserverclient import ServerResponseError
@@ -80,7 +81,7 @@ class GetUrl(DatasourcesAndWorkbooks):
     def get_file_type_from_filename(logger, url, file_name):
         logger.debug("Choosing between {}, {}".format(file_name, url))
         file_name = file_name or url
-        logger.debug(_("get.options.file") + ": {}".format(file_name))
+        logger.debug(_("get.options.file") + ": {}".format(file_name)) # Name to save the file as
         type_of_file = GetUrl.get_file_extension(file_name)
 
         if not type_of_file and file_name is not None:
@@ -97,26 +98,26 @@ class GetUrl(DatasourcesAndWorkbooks):
 
         Errors.exit_with_error(logger, _("tabcmd.get.extension.not_found").format(file_name))
 
+
     @staticmethod
-    def get_file_extension(filename):
-        parts = filename.split(".")
-        if len(parts) < 2:
-            return None
-        extension = parts[1]
+    def get_file_extension(path):
+        path_segments = os.path.split(path)
+        filename = path_segments[-1]
+        filename_segments = filename.split('.')
+        extension = filename_segments[-1]
         extension = GetUrl.strip_query_params(extension)
         return extension
 
     @staticmethod
     def strip_query_params(filename):
-        if filename.find("?") > 0:
-            filename = filename.split("?")[0]
-        return filename
+        if '?' in filename:
+            return filename.split("?")[0]
+        else:
+            return filename
 
     @staticmethod
     def get_name_without_possible_extension(filename):
-        if filename.find(".") > 0:
-            filename = filename.split(".")[0]
-        return filename
+        return filename.split(".")[0]
 
     @staticmethod
     def get_resource_name(url: str, logger):  # workbooks/wb-name" -> "wb-name", datasource/ds-name -> ds-name
@@ -181,7 +182,7 @@ class GetUrl(DatasourcesAndWorkbooks):
             filename = GetUrl.filename_from_args(args.filename, view_item.name, "pdf")
             DatasourcesAndWorkbooks.save_to_file(logger, view_item.pdf, filename)
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)
 
     @staticmethod
     def generate_png(logger, server, args, view_url):
@@ -195,7 +196,7 @@ class GetUrl(DatasourcesAndWorkbooks):
             filename = GetUrl.filename_from_args(args.filename, view_item.name, "png")
             DatasourcesAndWorkbooks.save_to_file(logger, view_item.image, filename)
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)
 
     @staticmethod
     def generate_csv(logger, server, args, view_url):
@@ -226,7 +227,7 @@ class GetUrl(DatasourcesAndWorkbooks):
             server.workbooks.download(target_workbook.id, filepath=file_name_with_path, no_extract=False)
             logger.info(_("export.success").format(target_workbook.name, file_name_with_ext))
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)
 
     @staticmethod
     def generate_tds(logger, server, args, file_extension):
@@ -243,4 +244,4 @@ class GetUrl(DatasourcesAndWorkbooks):
             server.datasources.download(target_datasource.id, filepath=file_name_with_path, no_extract=False)
             logger.info(_("export.success").format(target_datasource.name, file_name_with_ext))
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)

--- a/tabcmd/commands/datasources_and_workbooks/get_url_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/get_url_command.py
@@ -81,7 +81,7 @@ class GetUrl(DatasourcesAndWorkbooks):
     def get_file_type_from_filename(logger, url, file_name):
         logger.debug("Choosing between {}, {}".format(file_name, url))
         file_name = file_name or url
-        logger.debug(_("get.options.file") + ": {}".format(file_name)) # Name to save the file as
+        logger.debug(_("get.options.file") + ": {}".format(file_name))  # Name to save the file as
         type_of_file = GetUrl.get_file_extension(file_name)
 
         if not type_of_file and file_name is not None:
@@ -98,19 +98,18 @@ class GetUrl(DatasourcesAndWorkbooks):
 
         Errors.exit_with_error(logger, _("tabcmd.get.extension.not_found").format(file_name))
 
-
     @staticmethod
     def get_file_extension(path):
         path_segments = os.path.split(path)
         filename = path_segments[-1]
-        filename_segments = filename.split('.')
+        filename_segments = filename.split(".")
         extension = filename_segments[-1]
         extension = GetUrl.strip_query_params(extension)
         return extension
 
     @staticmethod
     def strip_query_params(filename):
-        if '?' in filename:
+        if "?" in filename:
             return filename.split("?")[0]
         else:
             return filename

--- a/tabcmd/commands/datasources_and_workbooks/publish_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/publish_command.py
@@ -74,8 +74,6 @@ class PublishCommand(DatasourcesAndWorkbooks):
 
             new_workbook = TSC.WorkbookItem(project_id, name=args.name, show_tabs=args.tabbed)
             try:
-                if creds:
-                    logger.debug("Workbook credentials object: " + str(creds))
                 new_workbook = server.workbooks.publish(
                     new_workbook,
                     args.filename,

--- a/tests/commands/test_execution.py
+++ b/tests/commands/test_execution.py
@@ -1,7 +1,6 @@
 import argparse
-import sys
 import unittest
-import mock
+import unittest.mock as mock
 from tabcmd.execution.logger_config import *
 from tabcmd.execution.tabcmd_controller import TabcmdController
 

--- a/tests/commands/test_geturl_utils.py
+++ b/tests/commands/test_geturl_utils.py
@@ -24,11 +24,10 @@ fake_item.name = "fake-name"
 fake_item.id = "fake-id"
 
 
-
 class FileHandling(unittest.TestCase):
 
     # get_file_type_from_filename(logger, url, filename)
-        # get_file_extension(filepath)
+    # get_file_extension(filepath)
     # evaluate_content_type(logger, url)
     # strip_query_params(filename)
     # get_name_without_possible_extension(fileanme)
@@ -37,7 +36,7 @@ class FileHandling(unittest.TestCase):
     # filename_from_args(file_arg, item_name, filetype)
 
     def test_get_view_with_chars_in_save_name(self):
-        filename="C:\\chase.culver\\docs\\downloaded.twbx" # W-13757625 fails if file path contains .
+        filename = "C:\\chase.culver\\docs\\downloaded.twbx"  # W-13757625 fails if file path contains .
         url = None
         filetype = GetUrl.get_file_type_from_filename(mock_logger, filename, url)
         assert filetype == "twbx", filetype
@@ -76,6 +75,7 @@ class FileHandling(unittest.TestCase):
         filename = "viewname"
         assert GetUrl.get_name_without_possible_extension(filename) == filename
 
+
 # handling our specific url-ish identifiers: /workbook/wb-name, etc
 class GeturlTests(unittest.TestCase):
     def test_get_workbook_name(self):
@@ -92,8 +92,6 @@ class GeturlTests(unittest.TestCase):
     GetUrl.get_view_without_extension(view_name)
     GetUrl.get_workbook(url)
     """
-
-
 
     """
     GetUrl.generate_twb(logger, server, args)

--- a/tests/commands/test_geturl_utils.py
+++ b/tests/commands/test_geturl_utils.py
@@ -24,7 +24,24 @@ fake_item.name = "fake-name"
 fake_item.id = "fake-id"
 
 
-class GeturlTests(unittest.TestCase):
+
+class FileHandling(unittest.TestCase):
+
+    # get_file_type_from_filename(logger, url, filename)
+        # get_file_extension(filepath)
+    # evaluate_content_type(logger, url)
+    # strip_query_params(filename)
+    # get_name_without_possible_extension(fileanme)
+    # get_resource_name(url, logger)
+    # get_view_url(url, logger)
+    # filename_from_args(file_arg, item_name, filetype)
+
+    def test_get_view_with_chars_in_save_name(self):
+        filename="C:\\chase.culver\\docs\\downloaded.twbx" # W-13757625 fails if file path contains .
+        url = None
+        filetype = GetUrl.get_file_type_from_filename(mock_logger, filename, url)
+        assert filetype == "twbx", filetype
+
     def test_evaluate_file_name_pdf(self):
         filename = "filename.pdf"
         url = None
@@ -59,6 +76,8 @@ class GeturlTests(unittest.TestCase):
         filename = "viewname"
         assert GetUrl.get_name_without_possible_extension(filename) == filename
 
+# handling our specific url-ish identifiers: /workbook/wb-name, etc
+class GeturlTests(unittest.TestCase):
     def test_get_workbook_name(self):
         assert GetUrl.get_resource_name("workbooks/wbname", mock_logger) == "wbname"
 
@@ -69,9 +88,14 @@ class GeturlTests(unittest.TestCase):
         assert GetUrl.get_view_url("views/wb-name/view-name?:refresh=y", None) == "wb-name/sheets/view-name"
 
     """
-    GetUrl.get_view_without_extension(view_name)
     GetUrl.get_view(url)
+    GetUrl.get_view_without_extension(view_name)
     GetUrl.get_workbook(url)
+    """
+
+
+
+    """
     GetUrl.generate_twb(logger, server, args)
     GetUrl.generate_pdf(logger, server, args)
     GetUrl.generate_png(logger, server, args)

--- a/tests/commands/test_session.py
+++ b/tests/commands/test_session.py
@@ -74,6 +74,7 @@ def _set_mocks_for_json_file_exists(mock_path, mock_json_lib, does_it_exist=True
         mock_json_lib.load.return_value = None
     return path
 
+
 def _set_mock_file_content(mock_load, expected_content):
     mock_load.return_value = expected_content
     return mock_load
@@ -119,6 +120,7 @@ class JsonTests(unittest.TestCase):
         mock_json.load = "just a string"
         test_session = Session()
         assert test_session.username is None
+
 
 @mock.patch("getpass.getpass")
 class BuildCredentialsTests(unittest.TestCase):

--- a/tests/e2e/online_tests.py
+++ b/tests/e2e/online_tests.py
@@ -38,7 +38,7 @@ server_admin = False
 site_admin = True
 project_admin = True
 extract_encryption_enabled = False
-use_tabcmd_classic = False # toggle between testing using tabcmd 2 or tabcmd classic
+use_tabcmd_classic = False  # toggle between testing using tabcmd 2 or tabcmd classic
 
 
 def _test_command(test_args: list[str]):
@@ -49,7 +49,11 @@ def _test_command(test_args: list[str]):
 
     # call the executable directly: lets us drop in classic tabcmd
     if use_tabcmd_classic:
-        calling_args = ["C:\\Program Files\\Tableau\\Tableau Server\\2023.3\\extras\\Command Line Utility\\tabcmd.exe"] + test_args + ["--no-certcheck"]
+        calling_args = (
+            ["C:\\Program Files\\Tableau\\Tableau Server\\2023.3\\extras\\Command Line Utility\\tabcmd.exe"]
+            + test_args
+            + ["--no-certcheck"]
+        )
     if database_password not in calling_args:
         print(calling_args)
     return subprocess.check_call(calling_args)
@@ -312,7 +316,7 @@ class OnlineCommandTest(unittest.TestCase):
         self._list("workbooks")
 
     @pytest.mark.order(8)
-    def test_list_workbooks(self):
+    def test_list_datasources(self):
         if use_tabcmd_classic:
             pytest.skip("not for tabcmd classic")
         self._list("datasources")


### PR DESCRIPTION
@W-13757625 - the command threw an error and failed if the filepath to save to contained a full stop, e.g
c:\users\chevy.chase\

Fixed by using os.path instead of manual parsing. Also added a test to cover the scenario.