### PR TITLE
Remove argparse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ classifiers = [
   "Programming Language :: Python :: 3.12"
 ]
 dependencies = [
-    'argparse',
     "appdirs",
     "doit",
     "ftfy",


### PR DESCRIPTION
`argparse` is a [Python standard module](https://docs.python.org/3/library/argparse.html) (Python > 3.2).