### PR TITLE
Fix for "this application can't be opened" error on opening tabcmd.app on Mac

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,7 +31,7 @@ jobs:
           - os: macos-13
             TARGET: macos
             CMD_BUILD:  >
-              pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos/tabcmd.app
+              pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos/
             BUNDLE_NAME: tabcmd.app
             OUT_FILE_NAME: tabcmd.app
             OUT_BINARY_FILE_NAME: tabcmd
@@ -39,7 +39,7 @@ jobs:
           - os: macos-latest
             TARGET: macos
             CMD_BUILD:  >
-              pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos/tabcmd_arm64.app
+              pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos/
             BUNDLE_NAME: tabcmd_arm64.app
             OUT_FILE_NAME: tabcmd.app
             OUT_BINARY_FILE_NAME: tabcmd
@@ -80,14 +80,14 @@ jobs:
     - name: Validate package for Mac
       if: matrix.TARGET == 'macos'
       run: |
-        ./dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}/${{ matrix.OUT_FILE_NAME }}/Contents/MacOS/tabcmd
+        ./dist/${{ matrix.TARGET }}/${{ matrix.OUT_FILE_NAME }}/Contents/MacOS/tabcmd
 
     - name: Tar app bundle for Mac
       if: matrix.TARGET == 'macos'
       run: |
-        rm -f dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}/tabcmd
+        rm -f dist/${{ matrix.TARGET }}/tabcmd
         cd dist/${{ matrix.TARGET }}
-        tar -cvf ${{ matrix.BUNDLE_NAME }}.tar ${{ matrix.BUNDLE_NAME }}
+        tar -cvf ${{ matrix.BUNDLE_NAME }}.tar ${{ matrix.OUT_FILE_NAME }}
 
     - name: Upload artifact
       if: matrix.TARGET != 'macos'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,7 +31,8 @@ jobs:
           - os: macos-13
             TARGET: macos
             CMD_BUILD:  >
-              pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos/tabcmd.app
+              pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos/tabcmd.app &&
+              chown -R --reference=. ./dist/macos/tabcmd.app
             OUT_FILE_NAME: tabcmd.app
             ASSET_MIME: application/zip
           - os: ubuntu-latest

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -80,7 +80,6 @@ jobs:
     - name: Validate package for Mac
       if: matrix.TARGET == 'macos'
       run: |
-        rm -f dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}/tabcmd
         ./dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}/${{ matrix.OUT_FILE_NAME }}/Contents/MacOS/tabcmd
 
     - name: Tar app bundle for Mac
@@ -101,5 +100,5 @@ jobs:
       if: matrix.TARGET == 'macos'
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.BUNDLE_NAME }}
+        name: ${{ matrix.BUNDLE_NAME }}.tar
         path: ./dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}.tar

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,9 +31,18 @@ jobs:
           - os: macos-13
             TARGET: macos
             CMD_BUILD:  >
-              pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos/tabcmd.app &&
-              chown -R $(whoami) ./dist/macos/tabcmd.app
+              pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos/tabcmd.app
+            BUNDLE_NAME: tabcmd.app
             OUT_FILE_NAME: tabcmd.app
+            OUT_BINARY_FILE_NAME: tabcmd
+            ASSET_MIME: application/zip
+          - os: macos-latest
+            TARGET: macos
+            CMD_BUILD:  >
+              pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos/tabcmd_arm64.app
+            BUNDLE_NAME: tabcmd_arm64.app
+            OUT_FILE_NAME: tabcmd.app
+            OUT_BINARY_FILE_NAME: tabcmd
             ASSET_MIME: application/zip
           - os: ubuntu-latest
             TARGET: ubuntu
@@ -68,14 +77,28 @@ jobs:
       if: matrix.TARGET != 'macos'
       run: ./dist/${{ matrix.TARGET }}/${{matrix.OUT_FILE_NAME}}
 
-    - name: Validate package for ${{matrix.TARGET}}
+    - name: Validate package for Mac
       if: matrix.TARGET == 'macos'
       run: |
-        rm -f dist/${{ matrix.TARGET }}/tabcmd.app/tabcmd
-        ls -tlr ./dist/${{ matrix.TARGET }}/${{ matrix.OUT_FILE_NAME }}/${{ matrix.OUT_FILE_NAME }}/Contents/MacOS/tabcmd
-        ./dist/${{ matrix.TARGET }}/${{ matrix.OUT_FILE_NAME }}/${{ matrix.OUT_FILE_NAME }}/Contents/MacOS/tabcmd
+        rm -f dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}/tabcmd
+        ./dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}/${{ matrix.OUT_FILE_NAME }}/Contents/MacOS/tabcmd
 
-    - uses: actions/upload-artifact@v4
+    - name: Tar app bundle for Mac
+      if: matrix.TARGET == 'macos'
+      run: |
+        rm -f dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}/tabcmd
+        tar -cvf dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}.tar dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}
+
+    - name: Upload artifact
+      if: matrix.TARGET != 'macos'
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.OUT_FILE_NAME }}
         path: ./dist/${{ matrix.TARGET }}/${{ matrix.OUT_FILE_NAME }}
+
+    - name: Upload artifact for Mac
+      if: matrix.TARGET == 'macos'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.BUNDLE_NAME }}
+        path: ./dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}.tar

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -72,6 +72,7 @@ jobs:
       if: matrix.TARGET == 'macos'
       run: |
         rm -f dist/${{ matrix.TARGET }}/tabcmd.app/tabcmd
+        ls -tlr ./dist/${{ matrix.TARGET }}/${{ matrix.OUT_FILE_NAME }}/${{ matrix.OUT_FILE_NAME }}/Contents/MacOS/tabcmd
         ./dist/${{ matrix.TARGET }}/${{ matrix.OUT_FILE_NAME }}/${{ matrix.OUT_FILE_NAME }}/Contents/MacOS/tabcmd
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -71,7 +71,7 @@ jobs:
       if: matrix.TARGET == 'macos'
       run: |
         rm -f dist/${{ matrix.TARGET }}/tabcmd.app/tabcmd
-        ls -ltr dist/${{ matrix.TARGET }}/tabcmd.app/
+        chmod 777 dist/${{ matrix.TARGET }}/${{matrix.OUT_FILE_NAME}}/${{matrix.OUT_FILE_NAME}}/Contents/MacOS/tabcmd
         ./dist/${{ matrix.TARGET }}/${{matrix.OUT_FILE_NAME}}/${{matrix.OUT_FILE_NAME}}/Contents/MacOS/tabcmd
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -100,5 +100,5 @@ jobs:
       if: matrix.TARGET == 'macos'
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.BUNDLE_NAME }}.tar
+        name: ${{ matrix.BUNDLE_NAME }}
         path: ./dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}.tar

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -70,7 +70,8 @@ jobs:
     - name: Validate package for ${{matrix.TARGET}}
       if: matrix.TARGET == 'macos'
       run: |
-        rm -f dist/${{ matrix.TARGET }}/tabcmd
+        rm -f dist/${{ matrix.TARGET }}/tabcmd.app/tabcmd
+        ls -ltr dist/${{ matrix.TARGET }}/tabcmd.app/
         ./dist/${{ matrix.TARGET }}/${{matrix.OUT_FILE_NAME}}/${{matrix.OUT_FILE_NAME}}/Contents/MacOS/tabcmd
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -32,7 +32,7 @@ jobs:
             TARGET: macos
             CMD_BUILD:  >
               pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos/tabcmd.app &&
-              chown -R --reference=. ./dist/macos/tabcmd.app
+              chown -R $(whoami) ./dist/macos/tabcmd.app
             OUT_FILE_NAME: tabcmd.app
             ASSET_MIME: application/zip
           - os: ubuntu-latest
@@ -72,7 +72,6 @@ jobs:
       if: matrix.TARGET == 'macos'
       run: |
         rm -f dist/${{ matrix.TARGET }}/tabcmd.app/tabcmd
-        chmod 777 dist/${{ matrix.TARGET }}/${{ matrix.OUT_FILE_NAME }}/${{ matrix.OUT_FILE_NAME }}/Contents/MacOS/tabcmd
         ./dist/${{ matrix.TARGET }}/${{ matrix.OUT_FILE_NAME }}/${{ matrix.OUT_FILE_NAME }}/Contents/MacOS/tabcmd
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -102,4 +102,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.BUNDLE_NAME }}
-        path: ./${{ matrix.BUNDLE_NAME }}.tar
+        path: ./dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}.tar

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,7 +34,7 @@ jobs:
               pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos/
             BUNDLE_NAME: tabcmd.app
             OUT_FILE_NAME: tabcmd.app
-            OUT_BINARY_FILE_NAME: tabcmd
+            APP_BINARY_FILE_NAME: tabcmd
             ASSET_MIME: application/zip
           - os: macos-latest
             TARGET: macos
@@ -42,7 +42,7 @@ jobs:
               pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos/
             BUNDLE_NAME: tabcmd_arm64.app
             OUT_FILE_NAME: tabcmd.app
-            OUT_BINARY_FILE_NAME: tabcmd
+            APP_BINARY_FILE_NAME: tabcmd
             ASSET_MIME: application/zip
           - os: ubuntu-latest
             TARGET: ubuntu
@@ -79,13 +79,12 @@ jobs:
 
     - name: Validate package for Mac
       if: matrix.TARGET == 'macos'
-      run: |
-        ./dist/${{ matrix.TARGET }}/${{ matrix.OUT_FILE_NAME }}/Contents/MacOS/tabcmd
+      run: ./dist/${{ matrix.TARGET }}/${{ matrix.OUT_FILE_NAME }}/Contents/MacOS/${{ matrix.APP_BINARY_FILE_NAME }}
 
     - name: Tar app bundle for Mac
       if: matrix.TARGET == 'macos'
       run: |
-        rm -f dist/${{ matrix.TARGET }}/tabcmd
+        rm -f dist/${{ matrix.TARGET }}/${{ matrix.APP_BINARY_FILE_NAME }}
         cd dist/${{ matrix.TARGET }}
         tar -cvf ${{ matrix.BUNDLE_NAME }}.tar ${{ matrix.OUT_FILE_NAME }}
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -64,7 +64,12 @@ jobs:
       run: ${{matrix.CMD_BUILD}}
 
     - name: Validate package for ${{matrix.TARGET}}
+      if: matrix.TARGET != 'macos'
       run: ./dist/${{ matrix.TARGET }}/${{matrix.OUT_FILE_NAME}}
+
+    - name: Validate package for ${{matrix.TARGET}}
+      if: matrix.TARGET == 'macos'
+      run: ./dist/${{ matrix.TARGET }}/${{matrix.OUT_FILE_NAME}}/Contents/MacOS/tabcmd
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -87,7 +87,8 @@ jobs:
       if: matrix.TARGET == 'macos'
       run: |
         rm -f dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}/tabcmd
-        tar -cvf dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}.tar dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}
+        cd dist/${{ matrix.TARGET }}
+        tar -cvf ${{ matrix.BUNDLE_NAME }}.tar ${{ matrix.BUNDLE_NAME }}
 
     - name: Upload artifact
       if: matrix.TARGET != 'macos'
@@ -101,4 +102,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.BUNDLE_NAME }}
-        path: ./dist/${{ matrix.TARGET }}/${{ matrix.BUNDLE_NAME }}.tar
+        path: ./${{ matrix.BUNDLE_NAME }}.tar

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -95,7 +95,7 @@ jobs:
         name: ${{ matrix.OUT_FILE_NAME }}
         path: ./dist/${{ matrix.TARGET }}/${{ matrix.OUT_FILE_NAME }}
 
-    - name: Upload artifact for Mac
+    - name: Upload artifact for Mac 
       if: matrix.TARGET == 'macos'
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,7 +31,7 @@ jobs:
           - os: macos-latest
             TARGET: macos
             CMD_BUILD:  >
-              pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos
+              pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos/tabcmd.app
             OUT_FILE_NAME: tabcmd.app
             ASSET_MIME: application/zip
           - os: ubuntu-latest
@@ -69,7 +69,9 @@ jobs:
 
     - name: Validate package for ${{matrix.TARGET}}
       if: matrix.TARGET == 'macos'
-      run: ./dist/${{ matrix.TARGET }}/${{matrix.OUT_FILE_NAME}}/Contents/MacOS/tabcmd
+      run: |
+        rm -f dist/${{ matrix.TARGET }}/tabcmd
+        ./dist/${{ matrix.TARGET }}/${{matrix.OUT_FILE_NAME}}/${{matrix.OUT_FILE_NAME}}/Contents/MacOS/tabcmd
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -28,7 +28,7 @@ jobs:
               pyinstaller tabcmd-windows.spec --clean --noconfirm --distpath ./dist/windows
             OUT_FILE_NAME: tabcmd.exe
             ASSET_MIME: application/vnd.microsoft.portable-executable
-          - os: macos-latest
+          - os: macos-13
             TARGET: macos
             CMD_BUILD:  >
               pyinstaller tabcmd-mac.spec --clean --noconfirm --distpath ./dist/macos/tabcmd.app
@@ -71,8 +71,8 @@ jobs:
       if: matrix.TARGET == 'macos'
       run: |
         rm -f dist/${{ matrix.TARGET }}/tabcmd.app/tabcmd
-        chmod 777 dist/${{ matrix.TARGET }}/${{matrix.OUT_FILE_NAME}}/${{matrix.OUT_FILE_NAME}}/Contents/MacOS/tabcmd
-        ./dist/${{ matrix.TARGET }}/${{matrix.OUT_FILE_NAME}}/${{matrix.OUT_FILE_NAME}}/Contents/MacOS/tabcmd
+        chmod 777 dist/${{ matrix.TARGET }}/${{ matrix.OUT_FILE_NAME }}/${{ matrix.OUT_FILE_NAME }}/Contents/MacOS/tabcmd
+        ./dist/${{ matrix.TARGET }}/${{ matrix.OUT_FILE_NAME }}/${{ matrix.OUT_FILE_NAME }}/Contents/MacOS/tabcmd
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3']
+        python-version: ['3.8', '3.9', '3.10', '3']
 
     runs-on: ${{ matrix.os }}
 

--- a/tabcmd-mac.spec
+++ b/tabcmd-mac.spec
@@ -40,8 +40,7 @@ exe = EXE(
     runtime_tmpdir=None,
     console=True,
     codesign_identity=None,
-    version='program_metadata.txt',
-    target_arch=universal2
+    version='program_metadata.txt'
 )
 
 app = BUNDLE(

--- a/tabcmd-mac.spec
+++ b/tabcmd-mac.spec
@@ -32,7 +32,7 @@ exe = EXE(
     a.zipfiles,
     a.datas,
     [],
-    name='tabcmd.app',
+    name='tabcmd',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
@@ -41,11 +41,12 @@ exe = EXE(
     console=True,
     codesign_identity=None,
     version='program_metadata.txt',
+    windowed=True
 )
 
 app = BUNDLE(
     exe,
-    name = 'tabcmd-app',
+    name = 'tabcmd.app',
     icon='res/tabcmd.icns',
     bundle_identifier = None,
 )

--- a/tabcmd-mac.spec
+++ b/tabcmd-mac.spec
@@ -40,8 +40,7 @@ exe = EXE(
     runtime_tmpdir=None,
     console=True,
     codesign_identity=None,
-    version='program_metadata.txt',
-    windowed=True
+    version='program_metadata.txt'
 )
 
 app = BUNDLE(

--- a/tabcmd-mac.spec
+++ b/tabcmd-mac.spec
@@ -40,7 +40,8 @@ exe = EXE(
     runtime_tmpdir=None,
     console=True,
     codesign_identity=None,
-    version='program_metadata.txt'
+    version='program_metadata.txt',
+    target_arch=universal2
 )
 
 app = BUNDLE(


### PR DESCRIPTION
**Issue:** "This application can't be opened" error was encountered on using the tabcmd.app on Mac environment from release artifacts

**Resolution:** The app wasn't properly bundled and the zip of the bundle associated with `actions/upload-artifact@v4` github action led to [loss of executable file's `+x` permission](https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss) and eventually led to aforementioned error while using the app. This PR addresses this issue by tar-ing the app bundle before uploading it to artifact thereby preserving the necessary file permissions