### PR TITLE
Jac/more mypy checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ required-version = 22
 target-version = ['py39', 'py310', 'py311']
 extend-exclude = '^/bin/*'
 [tool.mypy]
+check_untyped_defs = true
 disable_error_code = [
     'misc',
     'import'

--- a/tabcmd/commands/auth/login_command.py
+++ b/tabcmd/commands/auth/login_command.py
@@ -17,9 +17,9 @@ class LoginCommand(Server):
         # just uses global options
         pass
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         session.create_session(args, logger)

--- a/tabcmd/commands/auth/logout_command.py
+++ b/tabcmd/commands/auth/logout_command.py
@@ -17,9 +17,9 @@ class LogoutCommand(Server):
         # has no options
         pass
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         session.end_session_and_clear_data()

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -272,7 +272,7 @@ class Session:
             connected_server: TSC.Server = self.tableau_server
         else:
             Errors.exit_with_error(self.logger, "Attempted to sign in with no server connection created")
-        
+
         try:
             # it's the same call for token or user-pass
             connected_server = self.tableau_server.auth.sign_in(tableau_auth)
@@ -290,7 +290,6 @@ class Session:
         else:
             Errors.exit_with_error(self.logger, message="Sign in failed")
         return connected_server
-
 
     def _get_saved_credentials(self):
         if self.last_login_using == "username":

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -200,6 +200,9 @@ class Session:
         return tableau_server
 
     def _verify_server_connection_unauthed(self):
+        if not self.tableau_server:
+            Errors.exit_with_error(self.logger, "Attempted to verify non-existent server connection")
+            return  # make typing recognize self.tableau_server is not None after this line
         try:
             self.tableau_server.use_server_version()
         except requests.exceptions.ReadTimeout as timeout_error:
@@ -262,16 +265,14 @@ class Session:
     # TODO: pass in the server instance to auth?
     def _sign_in(self, tableau_auth) -> TSC.Server:
         self.logger.debug(_("session.login"))
-        self.logger.info(_("dataconnections.classes.tableau_server_site") + ": {}".format(self.site_name))
+        self.logger.info(_("dataconnections.classes.tableau_server_site") + ": {}".format(self._site_display_name()))
         # self.logger.debug(_("listsites.output").format("", self.username or self.token_name, self.site_name))
-        # must explicitly check 'is None' to treat the Optional as Not None
-        if self.tableau_server is not None:
-            connected_server: TSC.Server = self.tableau_server
-        else:
+        if not self.tableau_server:
             Errors.exit_with_error(self.logger, "Attempted to sign in with no server connection created")
-        
+            return  # make typing recognize self.tableau_server is not None after this line
         try:
-            connected_server.auth.sign_in(tableau_auth)
+            # it's the same call for token or user-pass
+            connected_server = self.tableau_server.auth.sign_in(tableau_auth)
         except Exception as e:
             Errors.exit_with_error(self.logger, exception=e)
         try:
@@ -305,7 +306,7 @@ class Session:
         self._read_existing_state()
         self._update_session_data(args)
         self.logging_level = args.logging_level or self.logging_level
-        self.logger = logger or log(__class__.__name__, self.logging_level)
+        self.logger = logger or log(self.__class__.__name__, self.logging_level)
 
         credentials = None
         if args.password or args.password_file:
@@ -367,8 +368,8 @@ class Session:
         self.tableau_server = None
 
         self.certificate = None
-        self.no_certcheck = None
-        self.no_proxy = None
+        self.no_certcheck = False
+        self.no_proxy = True
         self.proxy = None
         self.timeout = None
 
@@ -453,7 +454,7 @@ class Session:
             json.dump(data, f)
 
     def _serialize_for_save(self):
-        data = {"tableau_auth": []}
+        data: Any = {"tableau_auth": []}
         data["tableau_auth"].append(
             {
                 "auth_token": self.auth_token,

--- a/tabcmd/commands/auth/session.py
+++ b/tabcmd/commands/auth/session.py
@@ -265,11 +265,14 @@ class Session:
     # TODO: pass in the server instance to auth?
     def _sign_in(self, tableau_auth) -> TSC.Server:
         self.logger.debug(_("session.login"))
-        self.logger.info(_("dataconnections.classes.tableau_server_site") + ": {}".format(self._site_display_name()))
+        self.logger.info(_("dataconnections.classes.tableau_server_site") + ": {}".format(self.site_name))
         # self.logger.debug(_("listsites.output").format("", self.username or self.token_name, self.site_name))
-        if not self.tableau_server:
+        # must explicitly check 'is None' to treat the Optional as Not None
+        if self.tableau_server is not None:
+            connected_server: TSC.Server = self.tableau_server
+        else:
             Errors.exit_with_error(self.logger, "Attempted to sign in with no server connection created")
-            return  # make typing recognize self.tableau_server is not None after this line
+        
         try:
             # it's the same call for token or user-pass
             connected_server = self.tableau_server.auth.sign_in(tableau_auth)

--- a/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
@@ -1,3 +1,4 @@
+from typing import Union
 import urllib
 
 import tableauserverclient as TSC
@@ -5,6 +6,9 @@ import tableauserverclient as TSC
 from tabcmd.commands.constants import Errors
 from tabcmd.commands.server import Server
 from tabcmd.execution.localize import _
+
+# TODO: expose a base type for these
+RequestOptions = Union[TSC.PDFRequestOptions, TSC.CSVRequestOptions, TSC.ImageRequestOptions]
 
 
 class DatasourcesAndWorkbooks(Server):
@@ -62,7 +66,7 @@ class DatasourcesAndWorkbooks(Server):
         return matching_datasources[0]
 
     @staticmethod
-    def apply_values_from_url_params(logger, request_options: TSC.RequestOptions, url) -> None:
+    def apply_values_from_url_params(logger, request_options: TSC.RequestOptions, url: str) -> None:
         logger.debug(url)
         try:
             if "?" in url:
@@ -86,7 +90,7 @@ class DatasourcesAndWorkbooks(Server):
 
     # this is called from within from_url_params, for each view_filter value
     @staticmethod
-    def apply_encoded_filter_value(logger, request_options, value):
+    def apply_encoded_filter_value(logger, request_options: RequestOptions, value: str) -> None:
         # the REST API doesn't appear to have the option to disambiguate with "Parameters.<fieldname>"
         value = value.replace("Parameters.", "")
         # the filter values received from the url are already url encoded. tsc will encode them again.

--- a/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
@@ -16,9 +16,6 @@ class DatasourcesAndWorkbooks(Server):
     Base Class for Operations related to Datasources and Workbooks
     """
 
-    def __init__(self, args):
-        super().__init__(args)
-
     @staticmethod
     def get_view_url_from_names(wb_name, view_name):
         return "{}/sheets/{}".format(wb_name, view_name)

--- a/tabcmd/commands/datasources_and_workbooks/delete_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/delete_command.py
@@ -27,9 +27,9 @@ class DeleteCommand(DatasourcesAndWorkbooks):
         set_project_r_arg(group)
         set_parent_project_arg(group)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)
@@ -74,4 +74,4 @@ class DeleteCommand(DatasourcesAndWorkbooks):
                 server.datasources.delete(item_to_delete.id)
             logger.info(_("common.output.succeeded"))
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)

--- a/tabcmd/commands/datasources_and_workbooks/export_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/export_command.py
@@ -132,6 +132,7 @@ class ExportCommand(DatasourcesAndWorkbooks):
         except Exception as e:
             Errors.exit_with_error(logger, "Error saving to file", e)
 
+    # TODO should make the ability to pass in filters as args available in GET command too?
     @staticmethod
     def apply_filters_from_args(request_options: TSC.RequestOptions, args, logger=None) -> None:
         if args.filter:

--- a/tabcmd/commands/datasources_and_workbooks/export_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/export_command.py
@@ -73,9 +73,9 @@ class ExportCommand(DatasourcesAndWorkbooks):
     it to a file. This command can also export just the data used for a view_name
     """
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)
@@ -89,7 +89,7 @@ class ExportCommand(DatasourcesAndWorkbooks):
         if not view_content_url and not wb_content_url:
             view_example = "/workbook_name/view_name"
             message = "{} [{}]".format(
-                _("export.errors.requires_workbook_view_param").format(__class__.__name__), view_example
+                _("export.errors.requires_workbook_view_param").format(cls.__name__), view_example
             )
             Errors.exit_with_error(logger, message)
 

--- a/tabcmd/commands/datasources_and_workbooks/get_url_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/get_url_command.py
@@ -31,14 +31,14 @@ class GetUrl(DatasourcesAndWorkbooks):
         # tabcmd get "/views/Finance/InvestmentGrowth.png?:size=640,480" -f growth.png
         # tabcmd get "/views/Finance/InvestmentGrowth.png?:refresh=yes" -f growth.png
 
-    @staticmethod
-    def run_command(args):
+    @classmethod
+    def run_command(cls, args):
         # A view can be returned in PDF, PNG, or CSV (summary data only) format.
         # A Tableau workbook is returned as a TWB if it connects to a datasource/live connection,
         # or a TWBX if it uses an extract.
         # A Tableau datasource is returned as a TDS if it connects to a live connection,
         # or a TDSX if it uses an extract.
-        logger = log(__class__.__name__, args.logging_level)
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)

--- a/tabcmd/commands/datasources_and_workbooks/publish_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/publish_command.py
@@ -84,6 +84,7 @@ class PublishCommand(DatasourcesAndWorkbooks):
 
             new_workbook = TSC.WorkbookItem(project_id, name=args.name, show_tabs=args.tabbed)
             try:
+                print(creds)
                 new_workbook = server.workbooks.publish(
                     new_workbook,
                     args.filename,

--- a/tabcmd/commands/datasources_and_workbooks/publish_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/publish_command.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import tableauserverclient as TSC
 from tableauserverclient import ServerResponseError
 
@@ -112,7 +113,7 @@ class PublishCommand(DatasourcesAndWorkbooks):
     def get_publish_mode(args, logger):
         # default: fail if it already exists on the server
         default_mode = TSC.Server.PublishMode.CreateNew
-        publish_mode = default_mode
+        publish_mode : Optional[str] = default_mode
 
         if args.replace:
             raise AttributeError("Replacing an extract is not yet implemented")
@@ -131,7 +132,7 @@ class PublishCommand(DatasourcesAndWorkbooks):
                 # Overwrites the workbook, data source, or data extract if it already exists on the server.
                 publish_mode = TSC.Server.PublishMode.Overwrite
 
-        if not publish_mode:
+        if publish_mode is None:
             Errors.exit_with_error(logger, "Invalid combination of publishing options (Append, Overwrite, Replace)")
-        logger.debug("Publish mode selected: " + publish_mode)
+        logger.debug("Publish mode selected: " + str(publish_mode))
         return publish_mode

--- a/tabcmd/commands/datasources_and_workbooks/publish_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/publish_command.py
@@ -34,9 +34,9 @@ class PublishCommand(DatasourcesAndWorkbooks):
         set_append_replace_option(group)
         set_parent_project_arg(group)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)

--- a/tabcmd/commands/datasources_and_workbooks/publish_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/publish_command.py
@@ -115,7 +115,7 @@ class PublishCommand(DatasourcesAndWorkbooks):
     def get_publish_mode(args, logger):
         # default: fail if it already exists on the server
         default_mode = TSC.Server.PublishMode.CreateNew
-        publish_mode : Optional[str] = default_mode
+        publish_mode: Optional[str] = default_mode
 
         if args.replace:
             raise AttributeError("Replacing an extract is not yet implemented")

--- a/tabcmd/commands/datasources_and_workbooks/publish_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/publish_command.py
@@ -84,7 +84,8 @@ class PublishCommand(DatasourcesAndWorkbooks):
 
             new_workbook = TSC.WorkbookItem(project_id, name=args.name, show_tabs=args.tabbed)
             try:
-                print(creds)
+                if creds:
+                    logger.debug("Workbook credentials object: " + creds)
                 new_workbook = server.workbooks.publish(
                     new_workbook,
                     args.filename,

--- a/tabcmd/commands/datasources_and_workbooks/runschedule_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/runschedule_command.py
@@ -18,9 +18,9 @@ class RunSchedule(DatasourcesAndWorkbooks):
         group = runschedule_parser.add_argument_group(title=RunSchedule.name)
         group.add_argument("schedule", help="Name of the schedule to run")
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)

--- a/tabcmd/commands/extracts/create_extracts_command.py
+++ b/tabcmd/commands/extracts/create_extracts_command.py
@@ -26,9 +26,9 @@ class CreateExtracts(Server):
         set_project_arg(group)
         set_parent_project_arg(group)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)
@@ -39,9 +39,10 @@ class CreateExtracts(Server):
         )
         try:
             item = Extracts.get_wb_or_ds_for_extracts(args, logger, server)
+            job: TSC.JobItem
             if args.datasource:
                 logger.info(_("createextracts.for.datasource").format(args.datasource))
-                job: TSC.JobItem = server.datasources.create_extract(item, encrypt=args.encrypt)
+                job = server.datasources.create_extract(item, encrypt=args.encrypt)
 
             else:
                 if not args.include_all and not args.embedded_datasources:
@@ -51,7 +52,7 @@ class CreateExtracts(Server):
                     )
 
                 logger.info(_("createextracts.for.workbook_name").format(args.workbook))
-                job: TSC.JobItem = server.workbooks.create_extract(
+                job = server.workbooks.create_extract(
                     item,
                     encrypt=args.encrypt,
                     includeAll=args.include_all,
@@ -62,7 +63,7 @@ class CreateExtracts(Server):
             if args.continue_if_exists and Errors.is_resource_conflict(e):
                 logger.info(_("errors.xmlapi.already_exists").format(_("content_type.extract"), args.name))
                 return
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)
 
         logger.info(_("common.output.job_queued_success"))
         logger.debug("Extract creation queued with JobID: {}".format(job.id))

--- a/tabcmd/commands/extracts/decrypt_extracts_command.py
+++ b/tabcmd/commands/extracts/decrypt_extracts_command.py
@@ -19,9 +19,9 @@ class DecryptExtracts(Server):
         group = decrypt_extract_parser.add_argument_group(title=DecryptExtracts.name)
         group.add_argument("site_name", metavar="site-name", help=_("editsite.options.site-name"))
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)
@@ -30,7 +30,7 @@ class DecryptExtracts(Server):
             logger.info(_("decryptextracts.status").format(args.site_name))
             job = server.sites.decrypt_extracts(site_item.id)
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)
 
         logger.info(_("common.output.job_queued_success"))
         logger.debug("Extract decryption queued with JobID: {}".format(job.id))

--- a/tabcmd/commands/extracts/delete_extracts_command.py
+++ b/tabcmd/commands/extracts/delete_extracts_command.py
@@ -25,17 +25,18 @@ class DeleteExtracts(Server):
         set_project_arg(group)
         set_parent_project_arg(group)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)
         try:
             item = Extracts.get_wb_or_ds_for_extracts(args, logger, server)
+            job: TSC.JobItem
             if args.datasource:
                 logger.info(_("deleteextracts.for.datasource").format(args.datasource))
-                job: TSC.JobItem = server.datasources.delete_extract(item)
+                job = server.datasources.delete_extract(item)
             else:
                 if not args.include_all and not args.embedded_datasources:
                     Errors.exit_with_error(
@@ -43,12 +44,12 @@ class DeleteExtracts(Server):
                         _("extracts.workbook.errors.requires_datasources_or_include_all").format("deleteextracts"),
                     )
                 logger.info(_("deleteextracts.for.workbook_name").format(args.workbook))
-                job: TSC.JobItem = server.workbooks.delete_extract(
+                job = server.workbooks.delete_extract(
                     item, includeAll=args.include_all, datasources=args.embedded_datasources
                 )
 
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)
 
         logger.info(_("common.output.job_queued_success"))
         logger.debug("Extract deletion queued with JobID: {}".format(job.id))

--- a/tabcmd/commands/extracts/encrypt_extracts_command.py
+++ b/tabcmd/commands/extracts/encrypt_extracts_command.py
@@ -21,9 +21,9 @@ class EncryptExtracts(Server):
         group = encrypt_extract_parser.add_argument_group(title=EncryptExtracts.name)
         group.add_argument("site_name", metavar="site-name", help=_("editsite.options.site-name"))
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)
@@ -32,7 +32,7 @@ class EncryptExtracts(Server):
             logger.info(_("encryptextracts.status").format(site_item.name))
             job = server.sites.encrypt_extracts(site_item.id)
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)
 
         logger.info(_("common.output.job_queued_success"))
         logger.debug("Extract encryption queued with JobID: {}".format(job.id))

--- a/tabcmd/commands/extracts/extracts.py
+++ b/tabcmd/commands/extracts/extracts.py
@@ -18,12 +18,11 @@ class Extracts(Server):
             return datasource
 
         elif args.workbook or args.url:
+            workbook_item: TSC.WorkbookItem
             if args.workbook:
-                workbook_item: TSC.WorkbookItem = Server.get_workbook_item(logger, server, args.workbook, container)
+                workbook_item = Server.get_workbook_item(logger, server, args.workbook, container)
             else:
-                workbook_item: TSC.WorkbookItem = DatasourcesAndWorkbooks.get_wb_by_content_url(
-                    logger, server, args.url
-                )
+                workbook_item = DatasourcesAndWorkbooks.get_wb_by_content_url(logger, server, args.url)
             logger.info(_("export.status").format(workbook_item.name))
             return workbook_item
 

--- a/tabcmd/commands/extracts/reencrypt_extracts_command.py
+++ b/tabcmd/commands/extracts/reencrypt_extracts_command.py
@@ -21,9 +21,9 @@ class ReencryptExtracts(Server):
         group = reencrypt_extract_parser.add_argument_group(title=ReencryptExtracts.name)
         group.add_argument("site_name", metavar="site-name", help=_("editsite.options.site-name"))
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)
@@ -32,7 +32,7 @@ class ReencryptExtracts(Server):
             logger.info(_("reencryptextracts.status").format(site_item.name))
             job = server.sites.encrypt_extracts(site_item.id)
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)
 
         logger.info(_("common.output.job_queued_success"))
         logger.debug("Extract re-encryption queued with JobID: {}".format(job.id))

--- a/tabcmd/commands/extracts/refresh_extracts_command.py
+++ b/tabcmd/commands/extracts/refresh_extracts_command.py
@@ -24,9 +24,9 @@ class RefreshExtracts(Server):
         set_parent_project_arg(group)
         set_sync_wait_options(group)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)
@@ -40,11 +40,12 @@ class RefreshExtracts(Server):
 
         try:
             item = Extracts.get_wb_or_ds_for_extracts(args, logger, server)
+            job: TSC.JobItem
             if args.datasource:
                 logger.info(_("refreshextracts.status_refreshed").format(_("content_type.datasource"), args.datasource))
-                job: TSC.JobItem = server.datasources.refresh(item.id)
+                job = server.datasources.refresh(item.id)
             else:
-                job: TSC.JobItem = server.workbooks.refresh(item.id)
+                job = server.workbooks.refresh(item.id)
                 logger.info(_("refreshextracts.status_refreshed").format(_("content_type.workbook"), args.workbook))
 
         except Exception as e:
@@ -61,4 +62,4 @@ class RefreshExtracts(Server):
                 logger.info("Job completed: ")
                 logger.info(job_done)
             except Exception as je:
-                Errors.exit_with_error(logger, je)
+                Errors.exit_with_error(logger, exception=je)

--- a/tabcmd/commands/group/create_group_command.py
+++ b/tabcmd/commands/group/create_group_command.py
@@ -20,9 +20,9 @@ class CreateGroupCommand(Server):
         args_group = create_group_parser.add_argument_group(title=CreateGroupCommand.name)
         args_group.add_argument("name")
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)

--- a/tabcmd/commands/group/delete_group_command.py
+++ b/tabcmd/commands/group/delete_group_command.py
@@ -20,9 +20,9 @@ class DeleteGroupCommand(Server):
         args_group = delete_group_parser.add_argument_group(title=DeleteGroupCommand.name)
         args_group.add_argument("name")
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)

--- a/tabcmd/commands/project/create_project_command.py
+++ b/tabcmd/commands/project/create_project_command.py
@@ -25,9 +25,9 @@ class CreateProjectCommand(Server):
         set_parent_project_arg(create_project_parser)
         set_description_arg(create_project_parser)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)
@@ -37,8 +37,8 @@ class CreateProjectCommand(Server):
             try:
                 logger.debug(_("tabcmd.find.parent_project").format(args.parent_project_path))
                 parent = Server.get_project_by_name_and_parent_path(logger, server, None, args.parent_project_path)
-            except Exception as exc:
-                Errors.exit_with_error(logger, exc)
+            except Exception as e:
+                Errors.exit_with_error(logger, exception=e)
             readable_name = "{0}/{1}".format(args.parent_project_path, args.project_name)
             parent_id = parent.id
             logger.debug("parent project = `{0}`, id = {1}".format(args.parent_project_path, parent_id))
@@ -54,6 +54,6 @@ class CreateProjectCommand(Server):
                 logger.info(_("errors.xmlapi.already_exists").format(_("content_type.project"), args.project_name))
                 logger.info(_("common.output.succeeded"))
             else:
-                Errors.exit_with_error(logger, e)
+                Errors.exit_with_error(logger, exception=e)
 
         return project_item

--- a/tabcmd/commands/project/delete_project_command.py
+++ b/tabcmd/commands/project/delete_project_command.py
@@ -22,9 +22,9 @@ class DeleteProjectCommand(Server):
         args_group.add_argument("project_name", metavar="project-name", help=_("createproject.options.name"))
         set_parent_project_arg(args_group)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)
@@ -37,7 +37,7 @@ class DeleteProjectCommand(Server):
                 logger, server, args.project_name, args.parent_project_path
             )
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)
         project_id = project.id
 
         try:

--- a/tabcmd/commands/project/publish_samples_command.py
+++ b/tabcmd/commands/project/publish_samples_command.py
@@ -26,9 +26,9 @@ class PublishSamplesCommand(Server):
         )
         set_parent_project_arg(args_group)  # args.parent_project_name
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)

--- a/tabcmd/commands/server.py
+++ b/tabcmd/commands/server.py
@@ -141,7 +141,9 @@ class Server:
             )
 
     @staticmethod
-    def get_project_by_name_and_parent_path(logger, server, project_name: str, parent_path: str) -> TSC.ProjectItem:
+    def get_project_by_name_and_parent_path(
+        logger, server, project_name: Optional[str], parent_path: Optional[str]
+    ) -> TSC.ProjectItem:
         logger.debug(_("content_type.project") + ":{0}, {1}".format(parent_path, project_name))
         if not parent_path:
             if not project_name:
@@ -163,7 +165,7 @@ class Server:
         return project
 
     @staticmethod
-    def _parse_project_path_to_list(project_path: str):
+    def _parse_project_path_to_list(project_path: Optional[str]):
         if project_path is None or project_path == "":
             return []
         if project_path.find("/") == -1:

--- a/tabcmd/commands/site/create_site_command.py
+++ b/tabcmd/commands/site/create_site_command.py
@@ -22,9 +22,9 @@ class CreateSiteCommand(Server):
         args_group.add_argument("new_site_name", metavar="site-name", help=_("editsite.options.site-name"))
         set_common_site_args(args_group)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)
@@ -46,4 +46,4 @@ class CreateSiteCommand(Server):
             if Errors.is_resource_conflict(e) and args.continue_if_exists:
                 logger.info(_("createsite.errors.site_name_already_exists").format(args.new_site_name))
                 return
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)

--- a/tabcmd/commands/site/delete_site_command.py
+++ b/tabcmd/commands/site/delete_site_command.py
@@ -20,9 +20,9 @@ class DeleteSiteCommand(Server):
         args_group = delete_site_parser.add_argument_group(title=DeleteSiteCommand.name)
         args_group.add_argument("site_name_to_delete", metavar="site-name", help=strings[2])
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)

--- a/tabcmd/commands/site/edit_site_command.py
+++ b/tabcmd/commands/site/edit_site_command.py
@@ -25,9 +25,9 @@ class EditSiteCommand(Server):
         set_common_site_args(args_group)
         set_site_status_arg(args_group)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)
@@ -47,4 +47,4 @@ class EditSiteCommand(Server):
             logger.info(_("common.output.succeeded"))
 
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)

--- a/tabcmd/commands/site/list_command.py
+++ b/tabcmd/commands/site/list_command.py
@@ -29,8 +29,8 @@ class ListCommand(Server):
         )
         args_group.add_argument("-d", "--details", action="store_true", help="Show object details")
 
-    @staticmethod
-    def run_command(args):
+    @classmethod
+    def run_command(cls, args):
         logger = log(__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
@@ -63,4 +63,4 @@ class ListCommand(Server):
                     logger.info(ListCommand.local_strings["tabcmd_listing_label_name"].format(item.name))
 
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)

--- a/tabcmd/commands/site/list_sites_command.py
+++ b/tabcmd/commands/site/list_sites_command.py
@@ -21,9 +21,9 @@ class ListSiteCommand(Server):
         group = list_site_parser.add_argument_group(title=ListSiteCommand.name)
         set_site_detail_option(group)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)
@@ -35,4 +35,4 @@ class ListSiteCommand(Server):
                 if args.get_extract_encryption_mode:
                     logger.info("EXTRACTENCRYPTION: {}".format(site.extract_encryption_mode))
         except Exception as e:
-            Errors.exit_with_error(logger, e)
+            Errors.exit_with_error(logger, exception=e)

--- a/tabcmd/commands/user/add_users_command.py
+++ b/tabcmd/commands/user/add_users_command.py
@@ -20,9 +20,9 @@ class AddUserCommand(UserCommand):
         set_users_file_arg(args_group)
         set_completeness_options(args_group)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)

--- a/tabcmd/commands/user/create_site_users.py
+++ b/tabcmd/commands/user/create_site_users.py
@@ -26,9 +26,9 @@ class CreateSiteUsersCommand(UserCommand):
         set_completeness_options(args_group)
         UserCommand.set_auth_arg(args_group)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)

--- a/tabcmd/commands/user/create_users_command.py
+++ b/tabcmd/commands/user/create_users_command.py
@@ -26,9 +26,9 @@ class CreateUsersCommand(UserCommand):
         set_completeness_options(args_group)
         UserCommand.set_auth_arg(args_group)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)

--- a/tabcmd/commands/user/delete_site_users_command.py
+++ b/tabcmd/commands/user/delete_site_users_command.py
@@ -23,9 +23,9 @@ class DeleteSiteUsersCommand(Server):
         set_users_file_positional(args_group)
         set_completeness_options(args_group)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)

--- a/tabcmd/commands/user/remove_users_command.py
+++ b/tabcmd/commands/user/remove_users_command.py
@@ -20,9 +20,9 @@ class RemoveUserCommand(UserCommand):
         set_users_file_arg(args_group)
         set_completeness_options(args_group)
 
-    @staticmethod
-    def run_command(args):
-        logger = log(__class__.__name__, args.logging_level)
+    @classmethod
+    def run_command(cls, args):
+        logger = log(cls.__name__, args.logging_level)
         logger.debug(_("tabcmd.launching"))
         session = Session()
         server = session.create_session(args, logger)

--- a/tabcmd/execution/logger_config.py
+++ b/tabcmd/execution/logger_config.py
@@ -41,7 +41,7 @@ def add_trace_level():
     FORMATS[trace_level] = FORMATS[logging.ERROR]
 
 
-def configure_log(name: str, logging_level_input: str):
+def configure_log(name: str, logging_level_input: str) -> logging.Logger:
     """function for logging statements to console and logfile"""
     logging_level = getattr(logging, logging_level_input.upper())
     log_format = FORMATS[logging_level]
@@ -61,5 +61,5 @@ def configure_log(name: str, logging_level_input: str):
 def log(file_name, logging_level):
     logger = configure_log(file_name, logging_level)
     if not hasattr(logger, "trace"):
-        logger.trace = logger.debug
+        logger.trace = logger.debug  # type: ignore
     return logger

--- a/tabcmd/execution/parent_parser.py
+++ b/tabcmd/execution/parent_parser.py
@@ -199,7 +199,7 @@ class Help:
     def run_command(self, args):
         logger = log(__name__, "info")
         logger.info(strings[6] + " " + version + "\n")
-        logger.info(self.parser.root.format_help())
+        logger.info(self.parser.root.format_help())  # type: ignore
 
 
 strings = [

--- a/tabcmd/tabcmd.py
+++ b/tabcmd/tabcmd.py
@@ -17,13 +17,14 @@ def main():
         print("Keyboard Interrupt: exiting")
         sys.exit(1)
     except Exception as e:
-        sys.stderr.writelines(
-            [
-                "ERROR\n",
-                "Unhandled exception: {}\n".format(type(e).__name__),
-                f"at line {e.__traceback__.tb_lineno} of {__file__}: {e}\n",
-            ]
-        )
+        if e.__traceback__:
+            sys.stderr.writelines(
+                [
+                    "ERROR\n",
+                    "Unhandled exception: {}\n".format(type(e).__name__),
+                    f"at line {e.__traceback__.tb_lineno} of {__file__}: {e}\n",
+                ]
+            )
         sys.exit(1)
 
 

--- a/tests/commands/test_run_commands.py
+++ b/tests/commands/test_run_commands.py
@@ -158,14 +158,6 @@ class RunCommandsTest(unittest.TestCase):
         publish_command.PublishCommand.run_command(mock_args)
         mock_session.assert_called()
 
-    @unittest.skip("target code not implemented yet")
-    def test_runschedule(self, mock_session, mock_server):
-        RunCommandsTest._set_up_session(mock_session, mock_server)
-        mock_server.schedules = getter
-        mock_args.schedule = "myschedule"
-        with self.assertRaises(SystemExit):
-            runschedule_command.RunSchedule.run_command(mock_args)
-        # mock_session.assert_called()
 
     # extracts
     def test_create_extract(self, mock_session, mock_server):

--- a/tests/commands/test_session.py
+++ b/tests/commands/test_session.py
@@ -156,7 +156,7 @@ class BuildCredentialsTests(unittest.TestCase):
         test_password = "pword1"
         active_session = Session()
         active_session.username = "user"
-        active_session.site = ""
+        active_session.site_name = ""
         auth = active_session._create_new_credential(test_password, Session.PASSWORD_CRED_TYPE)
         assert auth is not None
 
@@ -175,7 +175,7 @@ class BuildCredentialsTests(unittest.TestCase):
     def test__create_new_username_credential_succeeds_from_self(self, mock_pass):
         active_session = Session()
         active_session.username = "user3"
-        active_session.site = ""
+        active_session.site_name = ""
         auth = active_session._create_new_credential(None, Session.PASSWORD_CRED_TYPE)
         assert mock_pass.has_been_called()
         assert auth is not None
@@ -201,18 +201,24 @@ class BuildCredentialsTests(unittest.TestCase):
 
 class PromptingTests(unittest.TestCase):
     def test_show_prompt_if_user_didnt_say(self):
+        session: Session = Session()
         test_args = Namespace(**vars(args_to_mock))
-        assert Session._allow_prompt(test_args) is True, test_args
+        session._update_session_data(test_args)
+        assert session._allow_prompt() is True, test_args
 
     def test_show_prompt_if_user_said_yes(self):
+        session: Session = Session()
         test_args = Namespace(**vars(args_to_mock))
         test_args.prompt = True
-        assert Session._allow_prompt(test_args) is True, test_args
+        session._update_session_data(test_args)
+        assert session._allow_prompt() is True, test_args
 
     def test_dont_show_prompt_if_user_said_no(self):
+        session: Session = Session()
         test_args = Namespace(**vars(args_to_mock))
         test_args.no_prompt = True
-        assert Session._allow_prompt(test_args) is False, test_args
+        session._update_session_data(test_args)
+        assert session._allow_prompt() is False, test_args
 
 
 """

--- a/tests/commands/test_user_utils.py
+++ b/tests/commands/test_user_utils.py
@@ -73,7 +73,8 @@ class UserDataTest(unittest.TestCase):
 
     def test_get_user_detail_standard(self):
         test_line = "username, pword, fname, license, admin, pub, email"
-        test_user: TSC.UserItem = UserCommand._parse_line(test_line)
+        test_user: TSC.UserItem | None = UserCommand._parse_line(test_line)
+        assert test_user is not None
         assert test_user.name == "username", test_user.name
         assert test_user.fullname == "fname", test_user.fullname
         assert test_user.site_role == "Unlicensed", test_user.site_role
@@ -81,7 +82,8 @@ class UserDataTest(unittest.TestCase):
 
     def test_get_user_details_only_username(self):
         test_line = "username"
-        test_user: TSC.UserItem = UserCommand._parse_line(test_line)
+        test_user: TSC.UserItem | None = UserCommand._parse_line(test_line)
+        assert test_user is not None
 
     def test_populate_user_details_only_some(self):
         values = ["username", "", "", "creator", "admin"]

--- a/tests/e2e/language_tests.py
+++ b/tests/e2e/language_tests.py
@@ -101,6 +101,12 @@ class OnlineCommandTest(unittest.TestCase):
         arguments = [command, server_file]
         _test_command(arguments)
 
+    def _get_workbook(self, server_file):
+        command = "get"
+        server_file = "/workbooks/" + server_file
+        arguments = [command, server_file]
+        _test_command(arguments)
+
     def _get_custom_view(self):
         command = "get"
 

--- a/tests/e2e/tests_integration.py
+++ b/tests/e2e/tests_integration.py
@@ -1,7 +1,9 @@
 import argparse
 import logging
 import pytest
+import tableauserverclient as TSC
 import unittest
+
 from tabcmd.commands.auth.session import Session
 from tabcmd.commands.server import Server
 from tabcmd.execution.logger_config import log
@@ -13,6 +15,7 @@ except ImportError:
     credentials = None  # type: ignore
 
 fakeserver = "http://SRVR"
+logger: logging.Logger
 logging.disable(logging.ERROR)
 
 # these are integration tests because they don't just run a command, they call interior methods
@@ -130,9 +133,8 @@ class E2EServerTests(unittest.TestCase):
         # test_session.create_session(args)
 
     def test_get_project(self):
-        logger = log(__class__.__name__, "info")
         server = E2EServerTests.test_log_in()
-        Server.get_project_by_name_and_parent_path(logger, server, "Default", None)
+        project: TSC.ProjectItem = Server.get_project_by_name_and_parent_path(logger, server, "Default", None)
 
 
 logging.disable(logging.NOTSET)

--- a/tests/parsers/common_setup.py
+++ b/tests/parsers/common_setup.py
@@ -1,6 +1,8 @@
+import argparse
+import unittest
+
 from tabcmd.execution import parent_parser
 from collections import namedtuple
-
 
 encoding = "utf-8-sig"
 
@@ -13,7 +15,7 @@ def mock_command_action():
 def initialize_test_pieces(commandname, command_object):
     manager = parent_parser.ParentParser()
     parser = manager.get_root_parser()
-    mock_command = namedtuple("TestObject", "name, run_command, description, define_args")
+    mock_command = namedtuple("mock_command", "name, run_command, description, define_args")
     mock_command.name = commandname
     mock_command.run_command = mock_command_action
     mock_command.description = "mock help text"
@@ -31,3 +33,7 @@ def initialize_test_pieces(commandname, command_object):
  bad mix of optional arguments
  has unknown arguments
  """
+
+
+class ParserTestCase(unittest.TestCase):
+    parser_under_test: argparse.ArgumentParser

--- a/tests/parsers/test_login_parser.py
+++ b/tests/parsers/test_login_parser.py
@@ -8,7 +8,7 @@ commandname = "login"
 
 
 @mock.patch("sys.argv", None)
-class LoginParserTest(unittest.TestCase):
+class LoginParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, LoginCommand)

--- a/tests/parsers/test_logout_parser.py
+++ b/tests/parsers/test_logout_parser.py
@@ -8,7 +8,7 @@ from .common_setup import *
 commandname = "logout"
 
 
-class LogoutParserTest(unittest.TestCase):
+class LogoutParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, LogoutCommand)

--- a/tests/parsers/test_parser_add_user.py
+++ b/tests/parsers/test_parser_add_user.py
@@ -7,7 +7,7 @@ from .common_setup import *
 commandname = "addusers"
 
 
-class AddUsersParserTest(unittest.TestCase):
+class AddUsersParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, AddUserCommand)
@@ -26,7 +26,7 @@ class AddUsersParserTest(unittest.TestCase):
         with mock.patch("builtins.open", mock.mock_open(read_data="test")) as open_file:
             mock_args = [commandname, "group-name", "--users", "users.csv"]
             args = self.parser_under_test.parse_args(mock_args)
-            self.assertEqual(args.name, "group-name"), args
+            self.assertEqual(args.name, "group-name", args)
             open_file.assert_called_with("users.csv", "r", -1, encoding, None), args
 
     @mock.patch("builtins.open")

--- a/tests/parsers/test_parser_create_extracts.py
+++ b/tests/parsers/test_parser_create_extracts.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "createextracts"
 
 
-class CreateExtractsParserTest(unittest.TestCase):
+class CreateExtractsParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, CreateExtracts)

--- a/tests/parsers/test_parser_create_group.py
+++ b/tests/parsers/test_parser_create_group.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "creategroup"
 
 
-class CreateGroupParserTest(unittest.TestCase):
+class CreateGroupParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, CreateGroupCommand)

--- a/tests/parsers/test_parser_create_project.py
+++ b/tests/parsers/test_parser_create_project.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "createproject"
 
 
-class CreateProjectParserTest(unittest.TestCase):
+class CreateProjectParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, CreateProjectCommand)

--- a/tests/parsers/test_parser_create_site.py
+++ b/tests/parsers/test_parser_create_site.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "createsite"
 
 
-class CreateSiteParserTest(unittest.TestCase):
+class CreateSiteParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, CreateSiteCommand)

--- a/tests/parsers/test_parser_create_site_users.py
+++ b/tests/parsers/test_parser_create_site_users.py
@@ -7,7 +7,7 @@ from .common_setup import *
 commandname = "createsiteusers"
 
 
-class CreateSiteUsersParserTest(unittest.TestCase):
+class CreateSiteUsersParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, CreateSiteUsersCommand)

--- a/tests/parsers/test_parser_create_user.py
+++ b/tests/parsers/test_parser_create_user.py
@@ -7,7 +7,7 @@ from .common_setup import *
 commandname = "createusers"
 
 
-class CreateUsersTest(unittest.TestCase):
+class CreateUsersTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, CreateUsersCommand)

--- a/tests/parsers/test_parser_decrypt_extracts.py
+++ b/tests/parsers/test_parser_decrypt_extracts.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "decryptextracts"
 
 
-class DecryptExtractsParserTest(unittest.TestCase):
+class DecryptExtractsParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, DecryptExtracts)

--- a/tests/parsers/test_parser_delete.py
+++ b/tests/parsers/test_parser_delete.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "delete"
 
 
-class DeleteParserTest(unittest.TestCase):
+class DeleteParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, DeleteCommand)

--- a/tests/parsers/test_parser_delete_extracts.py
+++ b/tests/parsers/test_parser_delete_extracts.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "deleteextracts"
 
 
-class DeleteExtractsParserTest(unittest.TestCase):
+class DeleteExtractsParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, DeleteExtracts)

--- a/tests/parsers/test_parser_delete_group.py
+++ b/tests/parsers/test_parser_delete_group.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "deletegroup"
 
 
-class DeleteGroupParserTestT(unittest.TestCase):
+class DeleteGroupParserTestT(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, DeleteGroupCommand)

--- a/tests/parsers/test_parser_delete_project.py
+++ b/tests/parsers/test_parser_delete_project.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "deleteproject"
 
 
-class DeleteProjectParserTest(unittest.TestCase):
+class DeleteProjectParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, DeleteProjectCommand)

--- a/tests/parsers/test_parser_delete_site.py
+++ b/tests/parsers/test_parser_delete_site.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "deletesite"
 
 
-class DeleteSiteParserTest(unittest.TestCase):
+class DeleteSiteParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, DeleteSiteCommand)

--- a/tests/parsers/test_parser_delete_site_user.py
+++ b/tests/parsers/test_parser_delete_site_user.py
@@ -7,7 +7,7 @@ from .common_setup import *
 commandname = "deletesiteusers"
 
 
-class DeleteSiteUsersParserTest(unittest.TestCase):
+class DeleteSiteUsersParserTest(ParserTestCase):
     csv = ("testname", "testpassword", "test", "test", "test", "test")
 
     @classmethod

--- a/tests/parsers/test_parser_edit_site.py
+++ b/tests/parsers/test_parser_edit_site.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "editsites"
 
 
-class EditSiteParserTest(unittest.TestCase):
+class EditSiteParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, EditSiteCommand)

--- a/tests/parsers/test_parser_encrypt_extracts.py
+++ b/tests/parsers/test_parser_encrypt_extracts.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "encryptextracts"
 
 
-class EncryptExtractsParserTest(unittest.TestCase):
+class EncryptExtractsParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, EncryptExtracts)

--- a/tests/parsers/test_parser_export.py
+++ b/tests/parsers/test_parser_export.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "export"
 
 
-class ExportParserTest(unittest.TestCase):
+class ExportParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, ExportCommand)

--- a/tests/parsers/test_parser_get_url.py
+++ b/tests/parsers/test_parser_get_url.py
@@ -6,13 +6,13 @@ from .common_setup import *
 commandname = "listsites"
 
 
-class GetUrlParserTest(unittest.TestCase):
+class GetUrlParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, GetUrl)
 
     def test_get_url_parser_file(self):
-        mock_args = vars(argparse.Namespace(filename="helloworld"))
+        mock_args = list(vars(argparse.Namespace(filename="helloworld")))
         with self.assertRaises(SystemExit):
             args = self.parser_under_test.parse_args(mock_args)
 

--- a/tests/parsers/test_parser_list_sites.py
+++ b/tests/parsers/test_parser_list_sites.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "listsites"
 
 
-class ListSitesParserTest(unittest.TestCase):
+class ListSitesParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, ListSiteCommand)

--- a/tests/parsers/test_parser_publish.py
+++ b/tests/parsers/test_parser_publish.py
@@ -7,7 +7,7 @@ from .common_setup import *
 commandname = "Publish"
 
 
-class PublishParserTest(unittest.TestCase):
+class PublishParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, PublishCommand)

--- a/tests/parsers/test_parser_publish_samples.py
+++ b/tests/parsers/test_parser_publish_samples.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "publishsamples"
 
 
-class PublishSamplesParserTest(unittest.TestCase):
+class PublishSamplesParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, PublishSamplesCommand)

--- a/tests/parsers/test_parser_reencrypt_extracts.py
+++ b/tests/parsers/test_parser_reencrypt_extracts.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "reencryptextracts"
 
 
-class ReencryptExtractsParserTest(unittest.TestCase):
+class ReencryptExtractsParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, ReencryptExtracts)

--- a/tests/parsers/test_parser_refresh_extracts.py
+++ b/tests/parsers/test_parser_refresh_extracts.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "refreshextracts"
 
 
-class RefreshExtractsParserTest(unittest.TestCase):
+class RefreshExtractsParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, RefreshExtracts)

--- a/tests/parsers/test_parser_remove_user.py
+++ b/tests/parsers/test_parser_remove_user.py
@@ -7,7 +7,7 @@ from .common_setup import *
 commandname = "removeusers"
 
 
-class RemoveUsersParserTest(unittest.TestCase):
+class RemoveUsersParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, RemoveUserCommand)

--- a/tests/parsers/test_parser_runschedule.py
+++ b/tests/parsers/test_parser_runschedule.py
@@ -6,7 +6,7 @@ from .common_setup import *
 commandname = "runschedule"
 
 
-class RunScheduleParserTest(unittest.TestCase):
+class RunScheduleParserTest(ParserTestCase):
     @classmethod
     def setUpClass(cls):
         cls.parser_under_test = initialize_test_pieces(commandname, RunSchedule)


### PR DESCRIPTION
enabled 'check_untyped_defs' so that methods without explicit type identifiers are still checked by mypy.
Found a number of places that this didn't work, so created comments to make an exception where needed.

Some minor refactoring needed to get types or null cases recognized, and run_command method was changed from static to class method. 