### PR TITLE
Fix for not retrieving all items when response has multiple pages of items

### DIFF
--- a/tabcmd/commands/server.py
+++ b/tabcmd/commands/server.py
@@ -50,31 +50,51 @@ class Server:
             container_name: str = "[{0}] {1}".format(container.__class__.__name__, container.name)
             item_log_name = "{0}/{1}".format(container_name, item_log_name)
         logger.debug(_("export.status").format(item_log_name))
-        req_option = TSC.RequestOptions()
-        req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Name, TSC.RequestOptions.Operator.Equals, item_name))
-        all_items, pagination_item = item_endpoint.get(req_option)
-        if all_items is None or all_items == []:
-            raise TSC.ServerResponseError(
-                code="404",
-                summary=_("errors.xmlapi.not_found"),
-                detail=_("errors.xmlapi.not_found") + ": " + item_log_name,
-            )
-        if len(all_items) == 1:
-            logger.debug("Exactly one result found")
-            result = all_items
-        if len(all_items) > 1:
-            logger.debug(
-                "{}+ items of this name were found: {}".format(
-                    len(all_items), all_items[0].name + ", " + all_items[1].name + ", ..."
+
+        result = []
+        total_available_items = None
+        page_number = 1
+        total_retrieved_items = 0
+
+        while True:
+            req_option = TSC.RequestOptions(pagenumber=page_number)
+            req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Name,
+                                             TSC.RequestOptions.Operator.Equals,
+                                             item_name))
+            all_items, pagination_item = item_endpoint.get(req_option)
+
+            if all_items is None or all_items == []:
+                raise TSC.ServerResponseError(
+                    code="404",
+                    summary=_("errors.xmlapi.not_found"),
+                    detail=_("errors.xmlapi.not_found") + ": " + item_log_name,
                 )
+
+            if total_available_items is None:
+                total_available_items = pagination_item.total_available
+
+            total_retrieved_items += len(all_items)
+
+            logger.debug(
+                "{} items of name: {} were found for query page number: {}, page size: {} & total available: {}"
+                .format(len(all_items),
+                        item_name,
+                        pagination_item.page_number,
+                        pagination_item.page_size,
+                        pagination_item.total_available)
             )
 
             if container:
                 container_id = container.id
                 logger.debug("Filtering to items in project {}".format(container.id))
-                result = list(filter(lambda item: item.project_id == container_id, all_items))
+                result.extend(list(filter(lambda item: item.project_id == container_id, all_items)))
             else:
-                result = all_items
+                result.extend(all_items)
+
+            if total_retrieved_items >= total_available_items:
+                break
+
+            page_number = pagination_item.page_number + 1
 
         return result
 

--- a/tabcmd/commands/server.py
+++ b/tabcmd/commands/server.py
@@ -1,5 +1,4 @@
 import os
-import concurrent.futures
 from typing import List, Optional
 
 import tableauserverclient as TSC
@@ -52,64 +51,53 @@ class Server:
             item_log_name = "{0}/{1}".format(container_name, item_log_name)
         logger.debug(_("export.status").format(item_log_name))
 
-        # Fetch the first page to determine the total number of pages
-        all_items, pagination_item = Server._fetch_items(logger, item_endpoint, item_name, 1)
-        if not all_items:
-            raise TSC.ServerResponseError(
-                code="404",
-                summary=_("errors.xmlapi.not_found"),
-                detail=_("errors.xmlapi.not_found") + ": " + item_log_name,
+        result = []
+        total_available_items = None
+        page_number = 1
+        total_retrieved_items = 0
+
+        while True:
+            req_option = TSC.RequestOptions(pagenumber=page_number)
+            req_option.filter.add(
+                TSC.Filter(TSC.RequestOptions.Field.Name, TSC.RequestOptions.Operator.Equals, item_name)
+            )
+            all_items, pagination_item = item_endpoint.get(req_option)
+
+            if all_items is None or all_items == []:
+                raise TSC.ServerResponseError(
+                    code="404",
+                    summary=_("errors.xmlapi.not_found"),
+                    detail=_("errors.xmlapi.not_found") + ": " + item_log_name,
+                )
+
+            if total_available_items is None:
+                total_available_items = pagination_item.total_available
+
+            total_retrieved_items += len(all_items)
+
+            logger.debug(
+                "{} items of name: {} were found for query page number: {}, page size: {} & total available: {}".format(
+                    len(all_items),
+                    item_name,
+                    pagination_item.page_number,
+                    pagination_item.page_size,
+                    pagination_item.total_available,
+                )
             )
 
-        total_available_items = pagination_item.total_available
-        page_size = pagination_item.page_size
-        total_pages = (total_available_items + page_size - 1) // page_size
+            if container:
+                container_id = container.id
+                logger.debug("Filtering to items in project {}".format(container.id))
+                result.extend(list(filter(lambda item: item.project_id == container_id, all_items)))
+            else:
+                result.extend(all_items)
 
-        result = Server._filter_items_by_container(logger, all_items, container)
+            if total_retrieved_items >= total_available_items:
+                break
 
-        # Use ThreadPoolExecutor to parallelize the fetching of remaining pages
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = [
-                executor.submit(Server._fetch_and_filter_items, logger, item_endpoint, item_name, page, container)
-                for page in range(2, total_pages + 1)
-            ]
-            for future in concurrent.futures.as_completed(futures):
-                result.extend(future.result())
+            page_number = pagination_item.page_number + 1
 
         return result
-
-    @staticmethod
-    def _fetch_and_filter_items(
-        logger, item_endpoint, item_name: str, page_number: int, container: Optional[TSC.ProjectItem]
-    ):
-        all_items, _ = Server._fetch_items(logger, item_endpoint, item_name, page_number)
-        return Server._filter_items_by_container(logger, all_items, container)
-
-    @staticmethod
-    def _fetch_items(logger, item_endpoint, item_name: str, page_number: int):
-        req_option = TSC.RequestOptions(pagenumber=page_number)
-        req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Name, TSC.RequestOptions.Operator.Equals, item_name))
-        all_items, pagination_item = item_endpoint.get(req_option)
-        logger.debug(
-            "{} items of name: {} were found for query page number: {}, page size: {} & total available: {}".format(
-                len(all_items),
-                item_name,
-                pagination_item.page_number,
-                pagination_item.page_size,
-                pagination_item.total_available,
-            )
-        )
-
-        return all_items, pagination_item
-
-    @staticmethod
-    def _filter_items_by_container(logger, all_items, container: Optional[TSC.ProjectItem]) -> List:
-        if container:
-            container_id = container.id
-            logger.debug("Filtering to items in project {}".format(container.id))
-            return list(filter(lambda item: item.project_id == container_id, all_items))
-
-        return all_items
 
     # Get site by name or get currently logged in site
     @staticmethod

--- a/tabcmd/commands/server.py
+++ b/tabcmd/commands/server.py
@@ -58,9 +58,9 @@ class Server:
 
         while True:
             req_option = TSC.RequestOptions(pagenumber=page_number)
-            req_option.filter.add(TSC.Filter(TSC.RequestOptions.Field.Name,
-                                             TSC.RequestOptions.Operator.Equals,
-                                             item_name))
+            req_option.filter.add(
+                TSC.Filter(TSC.RequestOptions.Field.Name, TSC.RequestOptions.Operator.Equals, item_name)
+            )
             all_items, pagination_item = item_endpoint.get(req_option)
 
             if all_items is None or all_items == []:
@@ -76,12 +76,13 @@ class Server:
             total_retrieved_items += len(all_items)
 
             logger.debug(
-                "{} items of name: {} were found for query page number: {}, page size: {} & total available: {}"
-                .format(len(all_items),
-                        item_name,
-                        pagination_item.page_number,
-                        pagination_item.page_size,
-                        pagination_item.total_available)
+                "{} items of name: {} were found for query page number: {}, page size: {} & total available: {}".format(
+                    len(all_items),
+                    item_name,
+                    pagination_item.page_number,
+                    pagination_item.page_size,
+                    pagination_item.total_available,
+                )
             )
 
             if container:

--- a/tabcmd/execution/parent_parser.py
+++ b/tabcmd/execution/parent_parser.py
@@ -134,6 +134,14 @@ def parent_parser_with_global_options():
         version=strings[6] + "v" + version + "\n \n",
         help=strings[7],
     )
+
+    parser.add_argument(
+        "--query-page-size",
+        type=int,
+        default=None,
+        metavar="<PAGE_SIZE>",
+        help="Specify the page size for query results.",
+    )
     return parser
 
 

--- a/tabcmd/execution/tabcmd_controller.py
+++ b/tabcmd/execution/tabcmd_controller.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 
 from .localize import set_client_locale
@@ -37,6 +38,8 @@ class TabcmdController:
             logger.debug(namespace)
         if namespace.language:
             set_client_locale(namespace.language, logger)
+        if namespace.query_page_size:
+            os.environ["TSC_PAGE_SIZE"] = str(namespace.query_page_size)
         try:
             func = namespace.func
             # if a subcommand was identified, call the function assigned to it

--- a/tests/commands/test_projects_utils.py
+++ b/tests/commands/test_projects_utils.py
@@ -7,7 +7,11 @@ from tabcmd.execution.logger_config import log
 fake_item = mock.MagicMock()
 fake_item.name = "fake-name"
 fake_item.id = "fake-id"
-getter = mock.MagicMock("get", return_value=([fake_item], 1))
+fake_item_pagination = mock.MagicMock()
+fake_item_pagination.page_number = 1
+fake_item_pagination.total_available = 1
+fake_item_pagination.page_size = 100
+getter = mock.MagicMock("get", return_value=([fake_item], fake_item_pagination))
 
 
 class ProjectsTest(unittest.TestCase):

--- a/tests/commands/test_publish_command.py
+++ b/tests/commands/test_publish_command.py
@@ -18,12 +18,17 @@ fake_item.id = "fake-id"
 fake_item.pdf = b"/pdf-representation-of-view"
 fake_item.extract_encryption_mode = "Disabled"
 
+fake_item_pagination = MagicMock()
+fake_item_pagination.page_number = 1
+fake_item_pagination.total_available = 1
+fake_item_pagination.page_size = 100
+
 fake_job = MagicMock()
 fake_job.id = "fake-job-id"
 
 creator = MagicMock()
 getter = MagicMock()
-getter.get = MagicMock("get", return_value=([fake_item], 1))
+getter.get = MagicMock("get", return_value=([fake_item], fake_item_pagination))
 getter.publish = MagicMock("publish", return_value=fake_item)
 
 

--- a/tests/commands/test_run_commands.py
+++ b/tests/commands/test_run_commands.py
@@ -37,15 +37,21 @@ mock_args = argparse.Namespace()
 fake_item = MagicMock()
 fake_item.name = "fake-name"
 fake_item.id = "fake-id"
+fake_item.project_id = "fake-id"
 fake_item.pdf = b"/pdf-representation-of-view"
 fake_item.extract_encryption_mode = "Disabled"
+
+fake_item_pagination = MagicMock()
+fake_item_pagination.page_number = 1
+fake_item_pagination.total_available = 1
+fake_item_pagination.page_size = 100
 
 fake_job = MagicMock()
 fake_job.id = "fake-job-id"
 
 creator = MagicMock()
 getter = MagicMock()
-getter.get = MagicMock("get", return_value=([fake_item], 1))
+getter.get = MagicMock("get", return_value=([fake_item], fake_item_pagination))
 getter.publish = MagicMock("publish", return_value=fake_item)
 getter.create_extract = MagicMock("create_extract", return_value=fake_job)
 getter.decrypt_extract = MagicMock("decrypt_extract", return_value=fake_job)
@@ -214,7 +220,6 @@ class RunCommandsTest(unittest.TestCase):
         mock_args.removecalculations = None
         mock_args.incremental = None
         mock_args.synchronous = None
-        print(mock_args)
 
         refresh_extracts_command.RefreshExtracts.run_command(mock_args)
         mock_session.assert_called()

--- a/tests/commands/test_server.py
+++ b/tests/commands/test_server.py
@@ -1,0 +1,222 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import tableauserverclient as TSC
+from tabcmd.commands.server import Server
+
+class TestServer(unittest.TestCase):
+
+    @patch('tabcmd.commands.server.TSC.RequestOptions')
+    @patch('tabcmd.commands.server.TSC.Filter')
+    def test_get_items_by_name_returns_items(self, MockFilter, MockRequestOptions):
+        logger = MagicMock()
+        item_endpoint = MagicMock()
+        item_name = "test_item"
+        container = None
+
+        pagination_item = MagicMock()
+        pagination_item.total_available = 1
+        pagination_item.page_number = 1
+        pagination_item.page_size = 1
+
+        item = MagicMock()
+        item_endpoint.get.return_value = ([item], pagination_item)
+
+        result = Server.get_items_by_name(logger, item_endpoint, item_name, container)
+
+        self.assertEqual(result, [item])
+        logger.debug.assert_called()
+        item_endpoint.get.assert_called()
+
+    @patch('tabcmd.commands.server.TSC.RequestOptions')
+    @patch('tabcmd.commands.server.TSC.Filter')
+    def test_get_items_by_name_no_items_found(self, MockFilter, MockRequestOptions):
+        logger = MagicMock()
+        item_endpoint = MagicMock()
+        item_name = "test_item"
+        container = None
+
+        pagination_item = MagicMock()
+        pagination_item.total_available = 0
+        pagination_item.page_number = 1
+        pagination_item.page_size = 1
+
+        item_endpoint.get.return_value = ([], pagination_item)
+
+        with self.assertRaises(TSC.ServerResponseError):
+            Server.get_items_by_name(logger, item_endpoint, item_name, container)
+
+        logger.debug.assert_called()
+        item_endpoint.get.assert_called()
+
+    @patch('tabcmd.commands.server.TSC.RequestOptions')
+    @patch('tabcmd.commands.server.TSC.Filter')
+    def test_get_items_by_name_with_container(self, MockFilter, MockRequestOptions):
+        logger = MagicMock()
+        item_endpoint = MagicMock()
+        item_name = "test_item"
+        container = MagicMock()
+        container.id = "container_id"
+
+        pagination_item = MagicMock()
+        pagination_item.total_available = 1
+        pagination_item.page_number = 1
+        pagination_item.page_size = 1
+
+        item = MagicMock()
+        item.project_id = "container_id"
+        item_endpoint.get.return_value = ([item], pagination_item)
+
+        result = Server.get_items_by_name(logger, item_endpoint, item_name, container)
+
+        self.assertEqual(result, [item])
+        logger.debug.assert_called()
+        item_endpoint.get.assert_called()
+
+    @patch('tabcmd.commands.server.TSC.RequestOptions')
+    @patch('tabcmd.commands.server.TSC.Filter')
+    def test_get_items_by_name_with_container_no_match(self, MockFilter, MockRequestOptions):
+        logger = MagicMock()
+        item_endpoint = MagicMock()
+        item_name = "test_item"
+        container = MagicMock()
+        container.id = "container_id"
+
+        pagination_item = MagicMock()
+        pagination_item.total_available = 1
+        pagination_item.page_number = 1
+        pagination_item.page_size = 1
+
+        item = MagicMock()
+        item.project_id = "different_container_id"
+        item_endpoint.get.return_value = ([item], pagination_item)
+
+        result = Server.get_items_by_name(logger, item_endpoint, item_name, container)
+
+        self.assertEqual(result, [])
+        logger.debug.assert_called()
+        item_endpoint.get.assert_called()
+
+    @patch('tabcmd.commands.server.TSC.RequestOptions')
+    @patch('tabcmd.commands.server.TSC.Filter')
+    def test_get_items_by_name_multiple_pages(self, MockFilter, MockRequestOptions):
+        logger = MagicMock()
+        item_endpoint = MagicMock()
+        item_name = "test_item"
+        container = None
+
+        pagination_item_1 = MagicMock()
+        pagination_item_1.total_available = 3
+        pagination_item_1.page_number = 1
+        pagination_item_1.page_size = 1
+
+        pagination_item_2 = MagicMock()
+        pagination_item_2.total_available = 3
+        pagination_item_2.page_number = 2
+        pagination_item_2.page_size = 1
+
+        pagination_item_3 = MagicMock()
+        pagination_item_3.total_available = 3
+        pagination_item_3.page_number = 3
+        pagination_item_3.page_size = 1
+
+        item_1 = MagicMock()
+        item_2 = MagicMock()
+        item_3 = MagicMock()
+
+        item_endpoint.get.side_effect = [
+            ([item_1], pagination_item_1),
+            ([item_2], pagination_item_2),
+            ([item_3], pagination_item_3)
+        ]
+
+        result = Server.get_items_by_name(logger, item_endpoint, item_name, container)
+
+        self.assertEqual(result, [item_1, item_2, item_3])
+        self.assertEqual(item_endpoint.get.call_count, 3)
+        logger.debug.assert_called()
+
+    @patch('tabcmd.commands.server.TSC.RequestOptions')
+    @patch('tabcmd.commands.server.TSC.Filter')
+    def test_get_items_by_name_multiple_pages_with_container(self, MockFilter, MockRequestOptions):
+        logger = MagicMock()
+        item_endpoint = MagicMock()
+        item_name = "test_item"
+        container = MagicMock()
+        container.id = "container_id"
+
+        pagination_item_1 = MagicMock()
+        pagination_item_1.total_available = 3
+        pagination_item_1.page_number = 1
+        pagination_item_1.page_size = 1
+
+        pagination_item_2 = MagicMock()
+        pagination_item_2.total_available = 3
+        pagination_item_2.page_number = 2
+        pagination_item_2.page_size = 1
+
+        pagination_item_3 = MagicMock()
+        pagination_item_3.total_available = 3
+        pagination_item_3.page_number = 3
+        pagination_item_3.page_size = 1
+
+        item_1 = MagicMock()
+        item_1.project_id = "container_id_1"
+        item_2 = MagicMock()
+        item_2.project_id = "container_id"
+        item_3 = MagicMock()
+        item_3.project_id = "container_id_2"
+
+        item_endpoint.get.side_effect = [
+            ([item_1], pagination_item_1),
+            ([item_2], pagination_item_2),
+            ([item_3], pagination_item_3)
+        ]
+
+        result = Server.get_items_by_name(logger, item_endpoint, item_name, container)
+
+        self.assertEqual(result, [item_2])
+        self.assertEqual(item_endpoint.get.call_count, 3)
+        logger.debug.assert_called()
+
+    @patch('tabcmd.commands.server.TSC.RequestOptions')
+    @patch('tabcmd.commands.server.TSC.Filter')
+    def test_get_items_by_name_multiple_pages_no_container_match(self, MockFilter, MockRequestOptions):
+        logger = MagicMock()
+        item_endpoint = MagicMock()
+        item_name = "test_item"
+        container = MagicMock()
+        container.id = "container_id"
+
+        pagination_item_1 = MagicMock()
+        pagination_item_1.total_available = 3
+        pagination_item_1.page_number = 1
+        pagination_item_1.page_size = 1
+
+        pagination_item_2 = MagicMock()
+        pagination_item_2.total_available = 3
+        pagination_item_2.page_number = 2
+        pagination_item_2.page_size = 1
+
+        pagination_item_3 = MagicMock()
+        pagination_item_3.total_available = 3
+        pagination_item_3.page_number = 3
+        pagination_item_3.page_size = 1
+
+        item_1 = MagicMock()
+        item_1.project_id = "different_container_id_1"
+        item_2 = MagicMock()
+        item_2.project_id = "different_container_id_2"
+        item_3 = MagicMock()
+        item_3.project_id = "different_container_id_3"
+
+        item_endpoint.get.side_effect = [
+            ([item_1], pagination_item_1),
+            ([item_2], pagination_item_2),
+            ([item_3], pagination_item_3)
+        ]
+
+        result = Server.get_items_by_name(logger, item_endpoint, item_name, container)
+
+        self.assertEqual(result, [])
+        self.assertEqual(item_endpoint.get.call_count, 3)
+        logger.debug.assert_called()

--- a/tests/commands/test_server.py
+++ b/tests/commands/test_server.py
@@ -3,10 +3,10 @@ from unittest.mock import MagicMock, patch
 import tableauserverclient as TSC
 from tabcmd.commands.server import Server
 
-class TestServer(unittest.TestCase):
 
-    @patch('tabcmd.commands.server.TSC.RequestOptions')
-    @patch('tabcmd.commands.server.TSC.Filter')
+class TestServer(unittest.TestCase):
+    @patch("tabcmd.commands.server.TSC.RequestOptions")
+    @patch("tabcmd.commands.server.TSC.Filter")
     def test_get_items_by_name_returns_items(self, MockFilter, MockRequestOptions):
         logger = MagicMock()
         item_endpoint = MagicMock()
@@ -27,8 +27,8 @@ class TestServer(unittest.TestCase):
         logger.debug.assert_called()
         item_endpoint.get.assert_called()
 
-    @patch('tabcmd.commands.server.TSC.RequestOptions')
-    @patch('tabcmd.commands.server.TSC.Filter')
+    @patch("tabcmd.commands.server.TSC.RequestOptions")
+    @patch("tabcmd.commands.server.TSC.Filter")
     def test_get_items_by_name_no_items_found(self, MockFilter, MockRequestOptions):
         logger = MagicMock()
         item_endpoint = MagicMock()
@@ -48,8 +48,8 @@ class TestServer(unittest.TestCase):
         logger.debug.assert_called()
         item_endpoint.get.assert_called()
 
-    @patch('tabcmd.commands.server.TSC.RequestOptions')
-    @patch('tabcmd.commands.server.TSC.Filter')
+    @patch("tabcmd.commands.server.TSC.RequestOptions")
+    @patch("tabcmd.commands.server.TSC.Filter")
     def test_get_items_by_name_with_container(self, MockFilter, MockRequestOptions):
         logger = MagicMock()
         item_endpoint = MagicMock()
@@ -72,8 +72,8 @@ class TestServer(unittest.TestCase):
         logger.debug.assert_called()
         item_endpoint.get.assert_called()
 
-    @patch('tabcmd.commands.server.TSC.RequestOptions')
-    @patch('tabcmd.commands.server.TSC.Filter')
+    @patch("tabcmd.commands.server.TSC.RequestOptions")
+    @patch("tabcmd.commands.server.TSC.Filter")
     def test_get_items_by_name_with_container_no_match(self, MockFilter, MockRequestOptions):
         logger = MagicMock()
         item_endpoint = MagicMock()
@@ -96,8 +96,8 @@ class TestServer(unittest.TestCase):
         logger.debug.assert_called()
         item_endpoint.get.assert_called()
 
-    @patch('tabcmd.commands.server.TSC.RequestOptions')
-    @patch('tabcmd.commands.server.TSC.Filter')
+    @patch("tabcmd.commands.server.TSC.RequestOptions")
+    @patch("tabcmd.commands.server.TSC.Filter")
     def test_get_items_by_name_multiple_pages(self, MockFilter, MockRequestOptions):
         logger = MagicMock()
         item_endpoint = MagicMock()
@@ -126,7 +126,7 @@ class TestServer(unittest.TestCase):
         item_endpoint.get.side_effect = [
             ([item_1], pagination_item_1),
             ([item_2], pagination_item_2),
-            ([item_3], pagination_item_3)
+            ([item_3], pagination_item_3),
         ]
 
         result = Server.get_items_by_name(logger, item_endpoint, item_name, container)
@@ -135,8 +135,8 @@ class TestServer(unittest.TestCase):
         self.assertEqual(item_endpoint.get.call_count, 3)
         logger.debug.assert_called()
 
-    @patch('tabcmd.commands.server.TSC.RequestOptions')
-    @patch('tabcmd.commands.server.TSC.Filter')
+    @patch("tabcmd.commands.server.TSC.RequestOptions")
+    @patch("tabcmd.commands.server.TSC.Filter")
     def test_get_items_by_name_multiple_pages_with_container(self, MockFilter, MockRequestOptions):
         logger = MagicMock()
         item_endpoint = MagicMock()
@@ -169,7 +169,7 @@ class TestServer(unittest.TestCase):
         item_endpoint.get.side_effect = [
             ([item_1], pagination_item_1),
             ([item_2], pagination_item_2),
-            ([item_3], pagination_item_3)
+            ([item_3], pagination_item_3),
         ]
 
         result = Server.get_items_by_name(logger, item_endpoint, item_name, container)
@@ -178,8 +178,8 @@ class TestServer(unittest.TestCase):
         self.assertEqual(item_endpoint.get.call_count, 3)
         logger.debug.assert_called()
 
-    @patch('tabcmd.commands.server.TSC.RequestOptions')
-    @patch('tabcmd.commands.server.TSC.Filter')
+    @patch("tabcmd.commands.server.TSC.RequestOptions")
+    @patch("tabcmd.commands.server.TSC.Filter")
     def test_get_items_by_name_multiple_pages_no_container_match(self, MockFilter, MockRequestOptions):
         logger = MagicMock()
         item_endpoint = MagicMock()
@@ -212,7 +212,7 @@ class TestServer(unittest.TestCase):
         item_endpoint.get.side_effect = [
             ([item_1], pagination_item_1),
             ([item_2], pagination_item_2),
-            ([item_3], pagination_item_3)
+            ([item_3], pagination_item_3),
         ]
 
         result = Server.get_items_by_name(logger, item_endpoint, item_name, container)


### PR DESCRIPTION
This pull request includes significant changes to the `get_items_by_name` function in `tabcmd/commands/server.py` to support pagination and improve item retrieval. Additionally, comprehensive unit tests have been added to ensure the function's correctness under various scenarios.