### PR TITLE
fix for error when item is not in first page

### DIFF
--- a/tests/commands/test_server.py
+++ b/tests/commands/test_server.py
@@ -73,7 +73,6 @@ class TestServer(unittest.TestCase):
         logger.debug.assert_called()
         item_endpoint.get.assert_called()
 
-
     @patch("tabcmd.commands.server.TSC.RequestOptions")
     @patch("tabcmd.commands.server.TSC.Filter")
     def test_get_items_by_name_multiple_pages(self, MockFilter, MockRequestOptions):

--- a/tests/commands/test_server.py
+++ b/tests/commands/test_server.py
@@ -1,3 +1,4 @@
+import pytest
 import unittest
 from unittest.mock import MagicMock, patch
 import tableauserverclient as TSC
@@ -72,29 +73,6 @@ class TestServer(unittest.TestCase):
         logger.debug.assert_called()
         item_endpoint.get.assert_called()
 
-    @patch("tabcmd.commands.server.TSC.RequestOptions")
-    @patch("tabcmd.commands.server.TSC.Filter")
-    def test_get_items_by_name_with_container_no_match(self, MockFilter, MockRequestOptions):
-        logger = MagicMock()
-        item_endpoint = MagicMock()
-        item_name = "test_item"
-        container = MagicMock()
-        container.id = "container_id"
-
-        pagination_item = MagicMock()
-        pagination_item.total_available = 1
-        pagination_item.page_number = 1
-        pagination_item.page_size = 1
-
-        item = MagicMock()
-        item.project_id = "different_container_id"
-        item_endpoint.get.return_value = ([item], pagination_item)
-
-        result = Server.get_items_by_name(logger, item_endpoint, item_name, container)
-
-        self.assertEqual(result, [])
-        logger.debug.assert_called()
-        item_endpoint.get.assert_called()
 
     @patch("tabcmd.commands.server.TSC.RequestOptions")
     @patch("tabcmd.commands.server.TSC.Filter")
@@ -132,91 +110,5 @@ class TestServer(unittest.TestCase):
         result = Server.get_items_by_name(logger, item_endpoint, item_name, container)
 
         self.assertEqual(result, [item_1, item_2, item_3])
-        self.assertEqual(item_endpoint.get.call_count, 3)
-        logger.debug.assert_called()
-
-    @patch("tabcmd.commands.server.TSC.RequestOptions")
-    @patch("tabcmd.commands.server.TSC.Filter")
-    def test_get_items_by_name_multiple_pages_with_container(self, MockFilter, MockRequestOptions):
-        logger = MagicMock()
-        item_endpoint = MagicMock()
-        item_name = "test_item"
-        container = MagicMock()
-        container.id = "container_id"
-
-        pagination_item_1 = MagicMock()
-        pagination_item_1.total_available = 3
-        pagination_item_1.page_number = 1
-        pagination_item_1.page_size = 1
-
-        pagination_item_2 = MagicMock()
-        pagination_item_2.total_available = 3
-        pagination_item_2.page_number = 2
-        pagination_item_2.page_size = 1
-
-        pagination_item_3 = MagicMock()
-        pagination_item_3.total_available = 3
-        pagination_item_3.page_number = 3
-        pagination_item_3.page_size = 1
-
-        item_1 = MagicMock()
-        item_1.project_id = "container_id_1"
-        item_2 = MagicMock()
-        item_2.project_id = "container_id"
-        item_3 = MagicMock()
-        item_3.project_id = "container_id_2"
-
-        item_endpoint.get.side_effect = [
-            ([item_1], pagination_item_1),
-            ([item_2], pagination_item_2),
-            ([item_3], pagination_item_3),
-        ]
-
-        result = Server.get_items_by_name(logger, item_endpoint, item_name, container)
-
-        self.assertEqual(result, [item_2])
-        self.assertEqual(item_endpoint.get.call_count, 3)
-        logger.debug.assert_called()
-
-    @patch("tabcmd.commands.server.TSC.RequestOptions")
-    @patch("tabcmd.commands.server.TSC.Filter")
-    def test_get_items_by_name_multiple_pages_no_container_match(self, MockFilter, MockRequestOptions):
-        logger = MagicMock()
-        item_endpoint = MagicMock()
-        item_name = "test_item"
-        container = MagicMock()
-        container.id = "container_id"
-
-        pagination_item_1 = MagicMock()
-        pagination_item_1.total_available = 3
-        pagination_item_1.page_number = 1
-        pagination_item_1.page_size = 1
-
-        pagination_item_2 = MagicMock()
-        pagination_item_2.total_available = 3
-        pagination_item_2.page_number = 2
-        pagination_item_2.page_size = 1
-
-        pagination_item_3 = MagicMock()
-        pagination_item_3.total_available = 3
-        pagination_item_3.page_number = 3
-        pagination_item_3.page_size = 1
-
-        item_1 = MagicMock()
-        item_1.project_id = "different_container_id_1"
-        item_2 = MagicMock()
-        item_2.project_id = "different_container_id_2"
-        item_3 = MagicMock()
-        item_3.project_id = "different_container_id_3"
-
-        item_endpoint.get.side_effect = [
-            ([item_1], pagination_item_1),
-            ([item_2], pagination_item_2),
-            ([item_3], pagination_item_3),
-        ]
-
-        result = Server.get_items_by_name(logger, item_endpoint, item_name, container)
-
-        self.assertEqual(result, [])
         self.assertEqual(item_endpoint.get.call_count, 3)
         logger.debug.assert_called()


### PR DESCRIPTION
I pushed the parent-project filter into the request so we only get the results that match, this means the result we want will always be on the first page (and will coincidentally improve performance of most queries by some extent)

We should rename this method [and others] to make it clear they will return exactly one item or throw an error.