### PR TITLE
Update tsc library to newest: 0.35

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "types-mock",
     "types-requests",
     "types-setuptools",
-    "tableauserverclient==0.34",
+    "tableauserverclient==0.35",
     "urllib3",
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
Simple library bump. This enables many necessary options like incremental publishing. 
https://github.com/tableau/server-client-python/releases/tag/v0.35