### PR TITLE
Improve error when run with no command given

### DIFF
--- a/tabcmd/execution/parent_parser.py
+++ b/tabcmd/execution/parent_parser.py
@@ -131,7 +131,7 @@ def parent_parser_with_global_options():
         "-v",
         "--version",
         action="version",
-        version=strings[6] + "v" + version + "\n \n",
+        version=strings[6] + " v" + version + "\n \n",
         help=strings[7],
     )
 

--- a/tabcmd/execution/parent_parser.py
+++ b/tabcmd/execution/parent_parser.py
@@ -182,6 +182,7 @@ class ParentParser:
         command.define_args(additional_parser)
         return additional_parser
 
+    # Help isn't added like the others because it has to have access to the rest, to get their args
     def include_help(self):
         additional_parser = self.subparsers.add_parser("help", help=strings[14], parents=[self.global_options])
         additional_parser._optionals.title = strings[1]

--- a/tabcmd/execution/tabcmd_controller.py
+++ b/tabcmd/execution/tabcmd_controller.py
@@ -26,32 +26,32 @@ class TabcmdController:
             sys.exit(0)
         user_input = user_input or sys.argv[1:]
         namespace = parser.parse_args(user_input)
+        # if no subcommand was given, call help
+        if not hasattr(namespace, "func"):
+            print("No command found.")
+            parser.print_help()
+            sys.exit(0)
+
         if hasattr("namespace", "logging_level") and namespace.logging_level != logging.INFO:
             print("logging:", namespace.logging_level)
 
         logger = log(__name__, namespace.logging_level or logging.INFO)
         logger.info("Tabcmd {}".format(version))
-        if (hasattr("namespace", "password") or hasattr("namespace", "token_value")) and hasattr("namespace", "func"):
+        if hasattr(namespace, "password") or hasattr(namespace, "token_value"):
             # don't print whole namespace because it has secrets
             logger.debug(namespace.func)
         else:
             logger.debug(namespace)
-        if namespace.language:
+        if hasattr(namespace, "language"):
             set_client_locale(namespace.language, logger)
         if namespace.query_page_size:
             os.environ["TSC_PAGE_SIZE"] = str(namespace.query_page_size)
         try:
-            func = namespace.func
-            # if a subcommand was identified, call the function assigned to it
-            # this is the functional equivalent of the call by reflection in the previous structure
             # https://stackoverflow.com/questions/49038616/argparse-subparsers-with-functions
             namespace.func.run_command(namespace)
-        except AttributeError:
-            parser.error("No command identified or too few arguments")
         except Exception as e:
             # todo: use log_stack here for better presentation?
             logger.exception(e)
-            # if no command was given, argparse will just not create the attribute
             sys.exit(2)
 
         return namespace

--- a/tabcmd/execution/tabcmd_controller.py
+++ b/tabcmd/execution/tabcmd_controller.py
@@ -46,6 +46,7 @@ class TabcmdController:
             set_client_locale(namespace.language, logger)
         if namespace.query_page_size:
             os.environ["TSC_PAGE_SIZE"] = str(namespace.query_page_size)
+
         try:
             # https://stackoverflow.com/questions/49038616/argparse-subparsers-with-functions
             namespace.func.run_command(namespace)


### PR DESCRIPTION


e.g "tabcmd --server --site --..."  would throw an exception about not having an attribute.
Now it will print out the usage information. 