### PR TITLE
Enable filtering when an entire workbook is exported

### DIFF
--- a/tabcmd/commands/datasources_and_workbooks/export_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/export_command.py
@@ -140,14 +140,12 @@ class ExportCommand(DatasourcesAndWorkbooks):
             for value in params:
                 ExportCommand.apply_filter_value(logger, request_options, value)
 
-    # filtering isn't actually implemented for workbooks in REST
     @staticmethod
     def download_wb_pdf(server, workbook_item, args, logger):
         logger.debug(args.url)
         pdf_options = TSC.PDFRequestOptions(maxage=1)
-        if args.filter or args.url.find("?") > 0:
-            logger.info("warning: Filter values will not be applied when exporting a complete workbook")
         ExportCommand.apply_values_from_url_params(logger, pdf_options, args.url)
+        ExportCommand.apply_filters_from_args(pdf_options, args, logger)
         ExportCommand.apply_pdf_options(logger, pdf_options, args)
         logger.debug(pdf_options.get_query_params())
         server.workbooks.populate_pdf(workbook_item, pdf_options)

--- a/tests/e2e/online_tests.py
+++ b/tests/e2e/online_tests.py
@@ -386,6 +386,12 @@ class OnlineCommandTest(unittest.TestCase):
         self._get_view(wb_name_on_server, sheet_name + ".csv")
 
     @pytest.mark.order(11)
+    def test_view_get_png(self):
+        wb_name_on_server = OnlineCommandTest.TWBX_WITH_EXTRACT_NAME
+        sheet_name = OnlineCommandTest.TWBX_WITH_EXTRACT_SHEET
+        self._get_view(wb_name_on_server, sheet_name + ".png")
+
+    @pytest.mark.order(11)
     def test_wb_publish_embedded(self):
         file = os.path.join("tests", "assets", OnlineCommandTest.TWB_WITH_EMBEDDED_CONNECTION)
         arguments = self._publish_args(file, OnlineCommandTest.EMBEDDED_TWB_NAME)

--- a/tests/e2e/online_tests.py
+++ b/tests/e2e/online_tests.py
@@ -188,7 +188,7 @@ class OnlineCommandTest(unittest.TestCase):
     # variation: url
     def _refresh_extract(self, type, wb_name):
         command = "refreshextracts"
-        arguments = [command, wb_name, "--project", default_project_name, "-w",]   # bug: should not need -w
+        arguments = [command, "-w", wb_name, "--project", default_project_name]   # bug: should not need -w
         try:
             _test_command(arguments)
         except Exception as e:
@@ -446,6 +446,15 @@ class OnlineCommandTest(unittest.TestCase):
     def test__delete_ds_live(self):
         name_on_server = OnlineCommandTest.TDS_FILE_LIVE_NAME
         self._delete_ds(name_on_server)
+
+    @pytest.mark.order(19)
+    def test_export_wb_filters(self):
+        wb_name_on_server = OnlineCommandTest.TWBX_WITH_EXTRACT_NAME
+        sheet_name = OnlineCommandTest.TWBX_WITH_EXTRACT_SHEET
+        friendly_name = wb_name_on_server +"/" + sheet_name
+        filters = ["--filter", "Product Type=Tea",  "--fullpdf", "--pagelayout", "landscape"]
+        self._export_wb(friendly_name, "filter_a_wb_to_tea_and_two_pages.pdf", filters)
+        # NOTE: this test needs a visual check on the returned pdf to confirm the expected appearance
 
     @pytest.mark.order(19)
     def test_export_wb_pdf(self):


### PR DESCRIPTION

Fixes #233 

example:
tabcmd export SampleWorkbook/Sheet1?Product%20Type=Tea   --fullpdf --pagelayout landscape

OR (new command format option, same output)
tabcmd export SampleWorkbook/Sheet1 --filter" "Product Type=Tea" --fullpdf --pagelayout landscape