### PR TITLE
Enable setting export image sizes 

### DIFF
--- a/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
@@ -144,7 +144,7 @@ class DatasourcesAndWorkbooks(Server):
         if args.height:
             request_options.viz_height = int(args.height)
         if args.width:
-            request_options.viz_width = args.width
+            request_options.viz_width = int(args.width)
         # Always request high-res images
         request_options.image_resolution = "high"
 

--- a/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
@@ -62,7 +62,7 @@ class DatasourcesAndWorkbooks(Server):
         return matching_datasources[0]
 
     @staticmethod
-    def apply_values_from_url_params(logger, request_options: TSC.PDFRequestOptions, url) -> None:
+    def apply_values_from_url_params(logger, request_options: TSC.RequestOptions, url) -> None:
         logger.debug(url)
         try:
             if "?" in url:

--- a/tabcmd/commands/datasources_and_workbooks/export_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/export_command.py
@@ -133,7 +133,7 @@ class ExportCommand(DatasourcesAndWorkbooks):
             Errors.exit_with_error(logger, "Error saving to file", e)
 
     @staticmethod
-    def apply_filters_from_args(request_options: TSC.PDFRequestOptions, args, logger=None) -> None:
+    def apply_filters_from_args(request_options: TSC.RequestOptions, args, logger=None) -> None:
         if args.filter:
             logger.debug("filter = {}".format(args.filter))
             params = args.filter.split("&")

--- a/tabcmd/commands/datasources_and_workbooks/export_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/export_command.py
@@ -140,14 +140,12 @@ class ExportCommand(DatasourcesAndWorkbooks):
             for value in params:
                 ExportCommand.apply_filter_value(logger, request_options, value)
 
-    # filtering isn't actually implemented for workbooks in REST
     @staticmethod
     def download_wb_pdf(server, workbook_item, args, logger):
         logger.debug(args.url)
         pdf_options = TSC.PDFRequestOptions(maxage=1)
-        if args.filter or args.url.find("?") > 0:
-            logger.info("warning: Filter values will not be applied when exporting a complete workbook")
         ExportCommand.apply_values_from_url_params(logger, pdf_options, args.url)
+        ExportCommand.apply_filters_from_args(pdf_options, args, logger)
         ExportCommand.apply_pdf_options(logger, pdf_options, args)
         logger.debug(pdf_options.get_query_params())
         server.workbooks.populate_pdf(workbook_item, pdf_options)

--- a/tabcmd/commands/datasources_and_workbooks/get_url_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/get_url_command.py
@@ -115,9 +115,9 @@ class GetUrl(DatasourcesAndWorkbooks):
         logger.trace("Entered method " + inspect.stack()[0].function)
         try:
             logger.debug(_("content_type.view") + ": {}".format(get_url_item.name))
-            req_option_csv = TSC.ImageRequestOptions(maxage=1)
-            DatasourcesAndWorkbooks.apply_values_from_url_params(logger, req_option_csv, args.url)
-            server_content_type.populate_image(get_url_item, req_option_csv)
+            req_option_png = TSC.ImageRequestOptions(maxage=1)
+            DatasourcesAndWorkbooks.apply_values_from_url_params(logger, req_option_png, args.url)
+            server_content_type.populate_image(get_url_item, req_option_png)
             filename = GetUrl.filename_from_args(args.filename, get_url_item.name, "png")
             DatasourcesAndWorkbooks.save_to_file(logger, get_url_item.image, filename)
         except Exception as e:

--- a/tests/commands/test_datasources_and_workbooks_command.py
+++ b/tests/commands/test_datasources_and_workbooks_command.py
@@ -54,7 +54,7 @@ class ParameterTests(unittest.TestCase):
         assert request_options.image_resolution == "high"
         assert request_options.viz_width == 800
         assert request_options.viz_height == 76
-        
+
     def test_apply_png_options_bad_values(self):
         mock_args.height = "seven"
         mock_args.width = "800b"

--- a/tests/commands/test_datasources_and_workbooks_command.py
+++ b/tests/commands/test_datasources_and_workbooks_command.py
@@ -47,12 +47,20 @@ class ParameterTests(unittest.TestCase):
         assert request_options.max_age == 0
 
     def test_apply_png_options(self):
-        # these aren't implemented yet. the layout and orientation ones don't apply.
-        mock_args.width = 800
-        mock_args.height = 76
+        mock_args.width = "800"
+        mock_args.height = "76"
         request_options = tsc.ImageRequestOptions()
         DatasourcesAndWorkbooks.apply_png_options(mock_logger, request_options, mock_args)
         assert request_options.image_resolution == "high"
+        assert request_options.viz_width == 800
+        assert request_options.viz_height == 76
+        
+    def test_apply_png_options_bad_values(self):
+        mock_args.height = "seven"
+        mock_args.width = "800b"
+        request_options = tsc.ImageRequestOptions()
+        with self.assertRaises(ValueError):
+            DatasourcesAndWorkbooks.apply_png_options(mock_logger, request_options, mock_args)
 
     def test_apply_pdf_options(self):
         expected_page = tsc.PDFRequestOptions.PageType.Folio.__str__()

--- a/tests/e2e/online_tests.py
+++ b/tests/e2e/online_tests.py
@@ -28,7 +28,7 @@ indexing_sleep_time = 1  # wait 1 second to confirm server has indexed updates
 unique = str(time.gmtime().tm_sec)
 group_name = "test-ing-group" + unique
 workbook_name = "wb_1_" + unique
-default_project_name = "Personal Work" # "default-proj" + unique
+default_project_name = "Personal Work"  # "default-proj" + unique
 parent_location = "parent" + unique
 project_name = "test-proj-" + unique
 
@@ -43,7 +43,7 @@ use_tabcmd_classic = False  # toggle between testing using tabcmd 2 or tabcmd cl
 def _test_command(test_args: list[str]):
     # this will raise an exception if it gets a non-zero return code
     # that will bubble up and fail the test
-    
+
     # default: run tests using tabcmd 2
     calling_args = ["python", "-m", "tabcmd"] + test_args + [debug_log] + ["--no-certcheck"]
 
@@ -120,7 +120,7 @@ class OnlineCommandTest(unittest.TestCase):
 
     def _delete_wb(self, name):
         command = "delete"
-        arguments = [command,  "--project", default_project_name, name] 
+        arguments = [command, "--project", default_project_name, name]
         _test_command(arguments)
 
     def _delete_ds(self, name):
@@ -142,20 +142,17 @@ class OnlineCommandTest(unittest.TestCase):
         # TODO
         command = "get"
 
-
-
     def _export_wb(self, friendly_name, filename=None, additional_args=None):
         command = "export"
         arguments = [command, friendly_name, "--fullpdf"]
-        
+
         if filename:
             arguments = arguments + ["--filename", filename]
         if additional_args:
             arguments = arguments + additional_args
         _test_command(arguments)
 
-        
-    def _export_view(self, wb_name_on_server, sheet_name, export_type, filename=None, additional_args=None):        
+    def _export_view(self, wb_name_on_server, sheet_name, export_type, filename=None, additional_args=None):
         server_file = "/" + wb_name_on_server + "/" + sheet_name
         command = "export"
         arguments = [command, server_file, export_type]
@@ -180,7 +177,7 @@ class OnlineCommandTest(unittest.TestCase):
 
     def _create_extract(self, type, wb_name):
         command = "createextracts"
-        arguments = [command, type, wb_name, "--project", default_project_name] 
+        arguments = [command, type, wb_name, "--project", default_project_name]
         if extract_encryption_enabled and not use_tabcmd_classic:
             arguments.append("--encrypt")
         _test_command(arguments)
@@ -188,7 +185,7 @@ class OnlineCommandTest(unittest.TestCase):
     # variation: url
     def _refresh_extract(self, type, wb_name):
         command = "refreshextracts"
-        arguments = [command, "-w", wb_name, "--project", default_project_name]   # bug: should not need -w
+        arguments = [command, "-w", wb_name, "--project", default_project_name]  # bug: should not need -w
         try:
             _test_command(arguments)
         except Exception as e:
@@ -202,7 +199,7 @@ class OnlineCommandTest(unittest.TestCase):
 
     def _delete_extract(self, type, item_name):
         command = "deleteextracts"
-        arguments = [command, type, item_name, "--include-all", "--project", default_project_name] 
+        arguments = [command, type, item_name, "--include-all", "--project", default_project_name]
         try:
             _test_command(arguments)
         except Exception as e:
@@ -380,6 +377,17 @@ class OnlineCommandTest(unittest.TestCase):
         self._get_view(wb_name_on_server, sheet_name, "downloaded_file.pdf")
 
     @pytest.mark.order(11)
+    def test_view_get_png_sizes(self):
+        wb_name_on_server = OnlineCommandTest.TWBX_WITH_EXTRACT_NAME
+        sheet_name = OnlineCommandTest.TWBX_WITH_EXTRACT_SHEET
+
+        self._get_view(wb_name_on_server, sheet_name, "get_view_default_size.png")
+        url_params = "?:size=100,200"
+        self._get_view(wb_name_on_server, sheet_name + url_params, "get_view_sized_sm.png")
+        url_params = "?:size=500,700"
+        self._get_view(wb_name_on_server, sheet_name + url_params, "get_view_sized_LARGE.png")
+
+    @pytest.mark.order(11)
     def test_view_get_csv(self):
         wb_name_on_server = OnlineCommandTest.TWBX_WITH_EXTRACT_NAME
         sheet_name = OnlineCommandTest.TWBX_WITH_EXTRACT_SHEET
@@ -451,21 +459,18 @@ class OnlineCommandTest(unittest.TestCase):
     def test_export_wb_filters(self):
         wb_name_on_server = OnlineCommandTest.TWBX_WITH_EXTRACT_NAME
         sheet_name = OnlineCommandTest.TWBX_WITH_EXTRACT_SHEET
-        friendly_name = wb_name_on_server +"/" + sheet_name
-        filters = ["--filter", "Product Type=Tea",  "--fullpdf", "--pagelayout", "landscape"]
+        friendly_name = wb_name_on_server + "/" + sheet_name
+        filters = ["--filter", "Product Type=Tea", "--fullpdf", "--pagelayout", "landscape"]
         self._export_wb(friendly_name, "filter_a_wb_to_tea_and_two_pages.pdf", filters)
         # NOTE: this test needs a visual check on the returned pdf to confirm the expected appearance
 
     @pytest.mark.order(19)
     def test_export_wb_pdf(self):
-        command = "export"
         wb_name_on_server = OnlineCommandTest.TWBX_WITH_EXTRACT_NAME
-        friendly_name = (
-            wb_name_on_server + "/" + OnlineCommandTest.TWBX_WITH_EXTRACT_SHEET 
-        )
+        friendly_name = wb_name_on_server + "/" + OnlineCommandTest.TWBX_WITH_EXTRACT_SHEET
         filename = "exported_wb.pdf"
         self._export_wb(friendly_name, filename)
-        
+
     @pytest.mark.order(19)
     def test_export_data_csv(self):
         wb_name_on_server = OnlineCommandTest.TWBX_WITH_EXTRACT_NAME
@@ -483,13 +488,13 @@ class OnlineCommandTest(unittest.TestCase):
         wb_name_on_server = OnlineCommandTest.TWBX_WITH_EXTRACT_NAME
         sheet_name = OnlineCommandTest.TWBX_WITH_EXTRACT_SHEET
         self._export_view(wb_name_on_server, sheet_name, "--pdf", "export_view_pdf.pdf")
-        
+
     @pytest.mark.order(19)
     def test_export_view_filtered(self):
         wb_name_on_server = OnlineCommandTest.TWBX_WITH_EXTRACT_NAME
         sheet_name = OnlineCommandTest.TWBX_WITH_EXTRACT_SHEET
         filename = "view_with_filters.pdf"
-        
+
         filters = ["--filter", "Product Type=Tea"]
         self._export_view(wb_name_on_server, sheet_name, "--pdf", filename, filters)
 

--- a/tests/e2e/online_tests.py
+++ b/tests/e2e/online_tests.py
@@ -188,7 +188,7 @@ class OnlineCommandTest(unittest.TestCase):
     # variation: url
     def _refresh_extract(self, type, wb_name):
         command = "refreshextracts"
-        arguments = [command, wb_name, "--project", default_project_name, "-w",]   # bug: should not need -w
+        arguments = [command, "-w", wb_name, "--project", default_project_name]   # bug: should not need -w
         try:
             _test_command(arguments)
         except Exception as e:
@@ -446,6 +446,15 @@ class OnlineCommandTest(unittest.TestCase):
     def test__delete_ds_live(self):
         name_on_server = OnlineCommandTest.TDS_FILE_LIVE_NAME
         self._delete_ds(name_on_server)
+
+    @pytest.mark.order(19)
+    def test_export_wb_filters(self):
+        wb_name_on_server = OnlineCommandTest.TWBX_WITH_EXTRACT_NAME
+        sheet_name = OnlineCommandTest.TWBX_WITH_EXTRACT_SHEET
+        friendly_name = wb_name_on_server +"/" + sheet_name
+        filters = ["--filter", "Product Type=Tea",  "--fullpdf", "--pagelayout", "landscape"]
+        self._export_wb(friendly_name, "filter_a_wb_to_tea_and_two_pages.pdf", filters)
+        # NOTE: this test needs a visual check on the returned pdf to confirm the expected appearance
 
     @pytest.mark.order(19)
     def test_export_wb_pdf(self):


### PR DESCRIPTION
(This PR is built on top of the open workbook filtering PR)

This now supports the get command with url params ?:size=x,y
and the export command with options --height, --weight

closes #94 