### PR TITLE
Add code coverage badge

### DIFF
--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -52,9 +52,12 @@ jobs:
         # Please submit an issue on this action's GitHub repo
         # report-only-changed-files: true
 
-    # TODO update badge on readme:
-    # generate badge with https://pypi.org/project/coverage-badge/
-    # display it with https://github.com/Schneegans/dynamic-badges-action
-
+    # https://github.com/marketplace/actions/coverage-badge
+    - name: Update Coverage Badge
+      # GitHub actions: default branch variable
+      # https://stackoverflow.com/questions/64781462/github-actions-default-branch-variable
+      if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+      uses: we-cli/coverage-badge-action@main
+        
     # TODO track docstring coverage
     # https://github.com/marketplace/actions/python-interrogate-check

--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -38,6 +38,10 @@ jobs:
     - name: Generate coverage report
       run: pytest --junitxml=pytest.xml --cov=tabcmd tests/ | tee pytest-coverage.txt
 
+    # trying another coverage reporter for PRs/badges
+    - name: Coveralls
+      uses: coverallsapp/github-action@v2
+
     - name: Comment on pull request with coverage
       uses: MishaKav/pytest-coverage-comment@main
       with:
@@ -47,14 +51,9 @@ jobs:
         # Please submit an issue on this action's GitHub repo
         # report-only-changed-files: true
 
-    # badge on readme: https://github.com/Schneegans/dynamic-badges-action
-    - name: Create Awesome Badge
-      uses: schneegans/dynamic-badges-action@v1.7.0
-      with:
-        auth: ${{ secrets.GIST_SECRET }}
-        gistID: 4f1a5e49fb58c3932bfdfdf22ed0a4b2
-        filename: coverage-badge.json # Use test.svg if you want to use the SVG mode.
-        label: Code Coverage
+    # TODO update badge on readme:
+    # generate badge with https://pypi.org/project/coverage-badge/
+    # display it with https://github.com/Schneegans/dynamic-badges-action
 
     # TODO track docstring coverage
     # https://github.com/marketplace/actions/python-interrogate-check

--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -47,9 +47,14 @@ jobs:
         # Please submit an issue on this action's GitHub repo
         # report-only-changed-files: true
 
-    # TODO update badge on readme:
-    # generate badge with https://pypi.org/project/coverage-badge/
-    # display it with https://github.com/Schneegans/dynamic-badges-action
+    # badge on readme: https://github.com/Schneegans/dynamic-badges-action
+    - name: Create Awesome Badge
+      uses: schneegans/dynamic-badges-action@v1.7.0
+      with:
+        auth: ${{ secrets.GIST_SECRET }}
+        gistID: 4f1a5e49fb58c3932bfdfdf22ed0a4b2
+        filename: coverage-badge.json # Use test.svg if you want to use the SVG mode.
+        label: Code Coverage
 
     # TODO track docstring coverage
     # https://github.com/marketplace/actions/python-interrogate-check

--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - development
+  workflow_dispatch:
 
 jobs:
   build:
@@ -12,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3']
+        python-version: ['3.12']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -51,13 +51,6 @@ jobs:
         # Error: The head commit for this pull_request event is not ahead of the base commit.
         # Please submit an issue on this action's GitHub repo
         # report-only-changed-files: true
-
-    # https://github.com/marketplace/actions/coverage-badge
-    - name: Update Coverage Badge
-      # GitHub actions: default branch variable
-      # https://stackoverflow.com/questions/64781462/github-actions-default-branch-variable
-      if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-      uses: we-cli/coverage-badge-action@main
         
     # TODO track docstring coverage
     # https://github.com/marketplace/actions/python-interrogate-check

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tableau Supported](https://img.shields.io/badge/Support%20Level-Tableau%20Supported-53bd92.svg)](https://www.tableau.com/support-levels-it-and-developer-tools)
 
-![Code Coverage](https://img.shields.io/endpoint?url=https://gist.github.com/jacalata/4f1a5e49fb58c3932bfdfdf22ed0a4b2/raw/coverage-badge.json)
+[![Code coverage](https://tableau.github.io/tabcmd/badges/coverage.svg)](https://github.com/tableau/tabcmd/actions)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Python tests](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml)
 [![Pypi smoke tests](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tableau Supported](https://img.shields.io/badge/Support%20Level-Tableau%20Supported-53bd92.svg)](https://www.tableau.com/support-levels-it-and-developer-tools)
 
-[![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/<user>/<gist-ID>/raw/coverage-badge.json)]
+![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/<user>/<gist-ID>/raw/coverage-badge.json)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Python tests](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml)
 [![Pypi smoke tests](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tableau Supported](https://img.shields.io/badge/Support%20Level-Tableau%20Supported-53bd92.svg)](https://www.tableau.com/support-levels-it-and-developer-tools)
 
-![Code Coverage](https://img.shields.io/badge/dynamic/json?url=https://gist.githubusercontent.com/<user>/<gist-ID>/raw/coverage-badge.json)
+![Code Coverage](https://img.shields.io/badge/dynamic/json?url=[https://gist.githubusercontent.com/<user>/<gist-ID>](https://gist.github.com/jacalata/4f1a5e49fb58c3932bfdfdf22ed0a4b2/raw/coverage-badge.json)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Python tests](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml)
 [![Pypi smoke tests](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tableau Supported](https://img.shields.io/badge/Support%20Level-Tableau%20Supported-53bd92.svg)](https://www.tableau.com/support-levels-it-and-developer-tools)
 
-[![Code coverage](https://tableau.github.io/tabcmd/badges/coverage.svg)](https://github.com/tableau/tabcmd/actions)
+[![Code coverage]([https://coveralls.io/repos/tableau/tabcmd/badge.png])(https://github.com/tableau/tabcmd/actions)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Python tests](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml)
 [![Pypi smoke tests](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tableau Supported](https://img.shields.io/badge/Support%20Level-Tableau%20Supported-53bd92.svg)](https://www.tableau.com/support-levels-it-and-developer-tools)
 
-![Code Coverage](https://img.shields.io/badge/dynamic/json?url=[https://gist.githubusercontent.com/<user>/<gist-ID>](https://gist.github.com/jacalata/4f1a5e49fb58c3932bfdfdf22ed0a4b2/raw/coverage-badge.json)
+![Code Coverage](https://img.shields.io/badge/dynamic/json?url=https://gist.github.com/jacalata/4f1a5e49fb58c3932bfdfdf22ed0a4b2/raw/coverage-badge.json)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Python tests](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml)
 [![Pypi smoke tests](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Tabcmd
 
 [![Tableau Supported](https://img.shields.io/badge/Support%20Level-Tableau%20Supported-53bd92.svg)](https://www.tableau.com/support-levels-it-and-developer-tools)
+
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/<user>/<gist-ID>/raw/coverage-badge.json)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Python tests](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml)
 [![Pypi smoke tests](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tableau Supported](https://img.shields.io/badge/Support%20Level-Tableau%20Supported-53bd92.svg)](https://www.tableau.com/support-levels-it-and-developer-tools)
 
-![Code Coverage](https://img.shields.io/badge/dynamic/json?url=https://gist.github.com/jacalata/4f1a5e49fb58c3932bfdfdf22ed0a4b2/raw/coverage-badge.json&query=message)
+![Code Coverage](https://img.shields.io/endpoint?url=https://gist.github.com/jacalata/4f1a5e49fb58c3932bfdfdf22ed0a4b2/raw/coverage-badge.json)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Python tests](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml)
 [![Pypi smoke tests](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tableau Supported](https://img.shields.io/badge/Support%20Level-Tableau%20Supported-53bd92.svg)](https://www.tableau.com/support-levels-it-and-developer-tools)
 
-![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/<user>/<gist-ID>/raw/coverage-badge.json)
+![Code Coverage](https://img.shields.io/badge/dynamic/json?url=https://gist.githubusercontent.com/<user>/<gist-ID>/raw/coverage-badge.json)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Python tests](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml)
 [![Pypi smoke tests](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tableau Supported](https://img.shields.io/badge/Support%20Level-Tableau%20Supported-53bd92.svg)](https://www.tableau.com/support-levels-it-and-developer-tools)
 
-![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/<user>/<gist-ID>/raw/coverage-badge.json)
+[![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/<user>/<gist-ID>/raw/coverage-badge.json)]
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Python tests](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml)
 [![Pypi smoke tests](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tableau Supported](https://img.shields.io/badge/Support%20Level-Tableau%20Supported-53bd92.svg)](https://www.tableau.com/support-levels-it-and-developer-tools)
 
-![Code Coverage](https://img.shields.io/badge/dynamic/json?url=https://gist.github.com/jacalata/4f1a5e49fb58c3932bfdfdf22ed0a4b2/raw/coverage-badge.json)
+![Code Coverage](https://img.shields.io/badge/dynamic/json?url=https://gist.github.com/jacalata/4f1a5e49fb58c3932bfdfdf22ed0a4b2/raw/coverage-badge.json&query=message)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Python tests](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/run-tests.yml)
 [![Pypi smoke tests](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml/badge.svg)](https://github.com/tableau/tabcmd/actions/workflows/python-app.yml)


### PR DESCRIPTION
Turns out github does not have a neat way to display code coverage. 

I added this repo to coveralls.io. This PR adds the code coverage action to start uploading to there when it is in main, and the badge specification that will display the status from coveralls.io once that is populated. 