### PR TITLE
Exporting pdf with height & width options not working as intended

### DIFF
--- a/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
@@ -156,6 +156,10 @@ class DatasourcesAndWorkbooks(Server):
             request_options.orientation = args.pagelayout
         if args.pagesize:
             request_options.page_type = args.pagesize
+        if args.height:
+            request_options.viz_height = int(args.height)
+        if args.width:
+            request_options.viz_width = int(args.width)
 
     @staticmethod
     def save_to_data_file(logger, output, filename):

--- a/tests/commands/test_datasources_and_workbooks_command.py
+++ b/tests/commands/test_datasources_and_workbooks_command.py
@@ -65,12 +65,18 @@ class ParameterTests(unittest.TestCase):
     def test_apply_pdf_options(self):
         expected_page = tsc.PDFRequestOptions.PageType.Folio.__str__()
         expected_layout = tsc.PDFRequestOptions.Orientation.Portrait.__str__()
+        expected_height = 800
+        expected_width = 600
         mock_args.pagelayout = expected_layout
         mock_args.pagesize = expected_page
+        mock_args.height = expected_height
+        mock_args.width = expected_width
         request_options = tsc.PDFRequestOptions()
         DatasourcesAndWorkbooks.apply_pdf_options(mock_logger, request_options, mock_args)
         assert request_options.page_type == expected_page
         assert request_options.orientation == expected_layout
+        assert request_options.viz_width == expected_width
+        assert request_options.viz_height == expected_height
 
 
 @mock.patch("tableauserverclient.Server")


### PR DESCRIPTION
Adding the specified height & width options to the export PDF's request