### PR TITLE
Adding support for args in publish and export commands

### DIFF
--- a/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
@@ -155,6 +155,8 @@ class DatasourcesAndWorkbooks(Server):
             request_options.image_resolution = None
         else:
             request_options.image_resolution = TSC.ImageRequestOptions.Resolution.High.lower()
+        if args.language:
+            request_options.language = args.language
 
     @staticmethod
     def apply_pdf_options(logger, request_options: TSC.PDFRequestOptions, args):
@@ -162,6 +164,13 @@ class DatasourcesAndWorkbooks(Server):
             request_options.orientation = args.pagelayout
         if args.pagesize:
             request_options.page_type = args.pagesize
+        if args.language:
+            request_options.language = args.language
+
+    @staticmethod
+    def apply_csv_options(logger, request_options: TSC.CSVRequestOptions, args):
+        if args.language:
+            request_options.language = args.language
 
     @staticmethod
     def save_to_data_file(logger, output, filename):

--- a/tabcmd/commands/datasources_and_workbooks/export_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/export_command.py
@@ -151,6 +151,8 @@ class ExportCommand(DatasourcesAndWorkbooks):
     def download_wb_pdf(server, workbook_item, args, logger):
         logger.debug(args.url)
         pdf_options = TSC.PDFRequestOptions(maxage=1)
+        if args.language:
+            pdf_options.language = args.language
         ExportCommand.apply_values_from_url_params(logger, pdf_options, args.url)
         ExportCommand.apply_filters_from_args(pdf_options, args, logger)
         ExportCommand.apply_pdf_options(logger, pdf_options, args)
@@ -162,6 +164,8 @@ class ExportCommand(DatasourcesAndWorkbooks):
     def download_view_pdf(server_content_type, export_item, args, logger):
         logger.debug(args.url)
         pdf_options = TSC.PDFRequestOptions(maxage=1)
+        if args.language:
+            pdf_options.language = args.language
         ExportCommand.apply_values_from_url_params(logger, pdf_options, args.url)
         ExportCommand.apply_filters_from_args(pdf_options, args, logger)
         ExportCommand.apply_pdf_options(logger, pdf_options, args)
@@ -173,6 +177,8 @@ class ExportCommand(DatasourcesAndWorkbooks):
     def download_csv(server_content_type, export_item, args, logger):
         logger.debug(args.url)
         csv_options = TSC.CSVRequestOptions(maxage=1)
+        if args.language:
+            csv_options.language = args.language
         ExportCommand.apply_values_from_url_params(logger, csv_options, args.url)
         ExportCommand.apply_filters_from_args(csv_options, args, logger)
         logger.debug(csv_options.get_query_params())
@@ -183,6 +189,8 @@ class ExportCommand(DatasourcesAndWorkbooks):
     def download_png(server_content_type, export_item, args, logger):
         logger.debug(args.url)
         image_options = TSC.ImageRequestOptions(maxage=1)
+        if args.language:
+            image_options.language = args.language
         ExportCommand.apply_values_from_url_params(logger, image_options, args.url)
         ExportCommand.apply_filters_from_args(image_options, args, logger)
         DatasourcesAndWorkbooks.apply_png_options(logger, image_options, args)

--- a/tabcmd/commands/datasources_and_workbooks/export_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/export_command.py
@@ -151,8 +151,6 @@ class ExportCommand(DatasourcesAndWorkbooks):
     def download_wb_pdf(server, workbook_item, args, logger):
         logger.debug(args.url)
         pdf_options = TSC.PDFRequestOptions(maxage=1)
-        if args.language:
-            pdf_options.language = args.language
         ExportCommand.apply_values_from_url_params(logger, pdf_options, args.url)
         ExportCommand.apply_filters_from_args(pdf_options, args, logger)
         ExportCommand.apply_pdf_options(logger, pdf_options, args)
@@ -164,8 +162,6 @@ class ExportCommand(DatasourcesAndWorkbooks):
     def download_view_pdf(server_content_type, export_item, args, logger):
         logger.debug(args.url)
         pdf_options = TSC.PDFRequestOptions(maxage=1)
-        if args.language:
-            pdf_options.language = args.language
         ExportCommand.apply_values_from_url_params(logger, pdf_options, args.url)
         ExportCommand.apply_filters_from_args(pdf_options, args, logger)
         ExportCommand.apply_pdf_options(logger, pdf_options, args)
@@ -177,10 +173,9 @@ class ExportCommand(DatasourcesAndWorkbooks):
     def download_csv(server_content_type, export_item, args, logger):
         logger.debug(args.url)
         csv_options = TSC.CSVRequestOptions(maxage=1)
-        if args.language:
-            csv_options.language = args.language
         ExportCommand.apply_values_from_url_params(logger, csv_options, args.url)
         ExportCommand.apply_filters_from_args(csv_options, args, logger)
+        DatasourcesAndWorkbooks.apply_csv_options(logger, csv_options, args)
         logger.debug(csv_options.get_query_params())
         server_content_type.populate_csv(export_item, csv_options)
         return export_item.csv
@@ -189,8 +184,6 @@ class ExportCommand(DatasourcesAndWorkbooks):
     def download_png(server_content_type, export_item, args, logger):
         logger.debug(args.url)
         image_options = TSC.ImageRequestOptions(maxage=1)
-        if args.language:
-            image_options.language = args.language
         ExportCommand.apply_values_from_url_params(logger, image_options, args.url)
         ExportCommand.apply_filters_from_args(image_options, args, logger)
         DatasourcesAndWorkbooks.apply_png_options(logger, image_options, args)

--- a/tabcmd/execution/global_options.py
+++ b/tabcmd/execution/global_options.py
@@ -327,7 +327,7 @@ def set_publish_args(parser):
     )
     thumbnails.add_argument(
         "--thumbnail-group",
-        help="[Not yet implemented] If the workbook contains user filters, the thumbnails will be generated based on what the "
+        help="If the workbook contains user filters, the thumbnails will be generated based on what the "
         "specified group can see. Cannot be specified when --thumbnail-username option is set.",
     )
 

--- a/tests/commands/test_datasources_and_workbooks_command.py
+++ b/tests/commands/test_datasources_and_workbooks_command.py
@@ -50,16 +50,30 @@ class ParameterTests(unittest.TestCase):
         mock_args.width = "800"
         mock_args.height = "76"
         mock_args.resolution = None
+        mock_args.language = None
         request_options = tsc.ImageRequestOptions()
         DatasourcesAndWorkbooks.apply_png_options(mock_logger, request_options, mock_args)
         assert request_options.image_resolution == "high"
         assert request_options.viz_width == 800
         assert request_options.viz_height == 76
 
+    def test_apply_png_options_with_language(self):
+        mock_args.width = "800"
+        mock_args.height = "76"
+        mock_args.resolution = None
+        mock_args.language = "de"
+        request_options = tsc.ImageRequestOptions()
+        DatasourcesAndWorkbooks.apply_png_options(mock_logger, request_options, mock_args)
+        assert request_options.image_resolution == "high"
+        assert request_options.viz_width == 800
+        assert request_options.viz_height == 76
+        assert request_options.language == "de"
+
     def test_apply_png_options_with_resolution_high(self):
         mock_args.width = "800"
         mock_args.height = "76"
         mock_args.resolution = "high"
+        mock_args.language = None
         request_options = tsc.ImageRequestOptions()
         DatasourcesAndWorkbooks.apply_png_options(mock_logger, request_options, mock_args)
         assert request_options.image_resolution == "high"
@@ -70,6 +84,7 @@ class ParameterTests(unittest.TestCase):
         mock_args.width = "800"
         mock_args.height = "76"
         mock_args.resolution = "standard"
+        mock_args.language = None
         request_options = tsc.ImageRequestOptions()
         DatasourcesAndWorkbooks.apply_png_options(mock_logger, request_options, mock_args)
         assert request_options.image_resolution is None
@@ -88,10 +103,24 @@ class ParameterTests(unittest.TestCase):
         expected_layout = tsc.PDFRequestOptions.Orientation.Portrait.__str__()
         mock_args.pagelayout = expected_layout
         mock_args.pagesize = expected_page
+        mock_args.language = None
         request_options = tsc.PDFRequestOptions()
         DatasourcesAndWorkbooks.apply_pdf_options(mock_logger, request_options, mock_args)
         assert request_options.page_type == expected_page
         assert request_options.orientation == expected_layout
+
+    def test_apply_pdf_options_with_language(self):
+        language = "de"
+        expected_page = tsc.PDFRequestOptions.PageType.Folio.__str__()
+        expected_layout = tsc.PDFRequestOptions.Orientation.Portrait.__str__()
+        mock_args.pagelayout = expected_layout
+        mock_args.pagesize = expected_page
+        mock_args.language = language
+        request_options = tsc.PDFRequestOptions()
+        DatasourcesAndWorkbooks.apply_pdf_options(mock_logger, request_options, mock_args)
+        assert request_options.page_type == expected_page
+        assert request_options.orientation == expected_layout
+        assert request_options.language == language
 
     def test_apply_options_in_url_with_size(self):
         request_options = tsc.ImageRequestOptions()
@@ -125,6 +154,18 @@ class ParameterTests(unittest.TestCase):
         self.assertEqual(request_options.viz_height, None)
         self.assertEqual(request_options.viz_width, None)
         self.assertEqual(request_options.max_age, default_max_age)
+
+    def test_apply_csv_options(self):
+        mock_args.language = None
+        request_options = tsc.CSVRequestOptions()
+        DatasourcesAndWorkbooks.apply_csv_options(mock_logger, request_options, mock_args)
+        assert request_options.language == None
+
+    def test_apply_csv_options_with_language(self):
+        mock_args.language = "de"
+        request_options = tsc.CSVRequestOptions()
+        DatasourcesAndWorkbooks.apply_csv_options(mock_logger, request_options, mock_args)
+        assert request_options.language == "de"
 
 
 @mock.patch("tableauserverclient.Server")

--- a/tests/commands/test_geturl_utils.py
+++ b/tests/commands/test_geturl_utils.py
@@ -18,6 +18,7 @@ mock_args.height = None
 mock_args.filename = None
 mock_args.filter = None
 mock_args.resolution = None
+mock_args.language = None
 
 mock_logger = mock.MagicMock()
 

--- a/tests/commands/test_run_commands.py
+++ b/tests/commands/test_run_commands.py
@@ -120,6 +120,7 @@ class RunCommandsTest(unittest.TestCase):
         mock_args.height = None
         mock_args.width = None
         mock_args.filter = None
+        #mock_args.language = None
         export_command.ExportCommand.run_command(mock_args)
         mock_session.assert_called()
 

--- a/tests/commands/test_run_commands.py
+++ b/tests/commands/test_run_commands.py
@@ -120,7 +120,7 @@ class RunCommandsTest(unittest.TestCase):
         mock_args.height = None
         mock_args.width = None
         mock_args.filter = None
-        #mock_args.language = None
+        mock_args.language = None
         export_command.ExportCommand.run_command(mock_args)
         mock_session.assert_called()
 


### PR DESCRIPTION
Adding support for
- `--replace` to publish command
- `--thumbnail-username` & `--thumbnail-group` options to publish command
- `--language` option in export commands