### PR TITLE
remove deprecated pkg_resources

### DIFF
--- a/tabcmd/version.py
+++ b/tabcmd/version.py
@@ -1,9 +1,8 @@
-# when we drop python 3.8, this could be replaced with this lighter weight option
-# from importlib.metadata import version, PackageNotFoundError
-from pkg_resources import get_distribution, DistributionNotFound
+# Updated to use importlib.metadata (available in Python 3.8+, required >= 3.9)
+from importlib.metadata import version, PackageNotFoundError
 
 try:
-    version = get_distribution("tabcmd").version
-except DistributionNotFound:
+    version = version("tabcmd")
+except PackageNotFoundError:
     version = "2.0.0"
     pass

--- a/tabcmd/version.py
+++ b/tabcmd/version.py
@@ -1,8 +1,7 @@
-# Updated to use importlib.metadata (available in Python 3.8+, required >= 3.9)
-from importlib.metadata import version, PackageNotFoundError
+import importlib.metadata as libs
 
 try:
-    version = version("tabcmd")
-except PackageNotFoundError:
+    version = libs.version("tabcmd")
+except libs.PackageNotFoundError:
     version = "2.0.0"
     pass


### PR DESCRIPTION
Python 3.8 was EOL in 2024