### PR TITLE
refreshextracts refreshes the wrong extract if you have multiple data sources with the same name and same Project name

### DIFF
--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
       uses: actions/setup-python@v5

--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/generate-metadata.yml
+++ b/.github/workflows/generate-metadata.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/generate-metadata.yml
+++ b/.github/workflows/generate-metadata.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.12
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -60,7 +60,7 @@ jobs:
             UPLOAD_FILE_NAME: tabcmd
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build dist files for PyPi
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v5

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.12
       - name: Build dist files

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: pip install Tabcmd

--- a/.github/workflows/run-e2-tests.yml
+++ b/.github/workflows/run-e2-tests.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/run-e2-tests.yml
+++ b/.github/workflows/run-e2-tests.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
       uses: actions/setup-python@v5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
       uses: actions/setup-python@v5

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+404: Not Found#ECCN:Open Source

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-404: Not Found#ECCN:Open Source
+#ECCN:Open Source

--- a/tabcmd/commands/server.py
+++ b/tabcmd/commands/server.py
@@ -62,9 +62,9 @@ class Server:
                 TSC.Filter(TSC.RequestOptions.Field.Name, TSC.RequestOptions.Operator.Equals, item_name)
             )
 
-            # todo - this doesn't filter if the project is in the top level.
-            # todo: there is no guarantee that these fields are the same for different content types.
-            # probably better if we move that type specific logic out to a wrapper
+            # When a container (project) is provided, add a parent filter to narrow results coming back
+            # from the server, then additionally post-filter client-side by project_id to disambiguate
+            # cases where multiple projects share the same name under different parent paths.
             if container:
                 # the name of the filter field is different if you are finding a project or any other item
                 if type(item_endpoint).__name__.find("Projects") < 0:
@@ -86,6 +86,11 @@ class Server:
                     detail=_("errors.xmlapi.not_found") + ": " + item_log_name,
                 )
 
+            # Post-filter by exact project_id when looking up non-project items within a specific container.
+            # This prevents selecting a similarly named item from a sibling project that shares the same name.
+            if container and type(item_endpoint).__name__.find("Projects") < 0:
+                all_items = [i for i in all_items if getattr(i, "project_id", None) == container.id]
+
             total_retrieved_items += len(all_items)
 
             logger.debug(
@@ -99,10 +104,26 @@ class Server:
             )
 
             result.extend(all_items)
+
+            # Once we have disambiguated items for a specific container/project, there is no need to
+            # continue paginating further since additional pages would return the same name-matched
+            # items from other projects which are filtered out, leading to duplicates.
+            if container and type(item_endpoint).__name__.find("Projects") < 0 and len(all_items) > 0:
+                break
+
             if total_retrieved_items >= pagination_item.total_available:
                 break
 
             page_number = pagination_item.page_number + 1
+
+        # If a container was provided and no items remained after disambiguation by project_id,
+        # surface a not-found to align with server-side not-found semantics.
+        if container and type(item_endpoint).__name__.find("Projects") < 0 and len(result) == 0:
+            raise TSC.ServerResponseError(
+                code="404",
+                summary=_("errors.xmlapi.not_found"),
+                detail=_("errors.xmlapi.not_found") + ": " + item_log_name,
+            )
 
         return result
 

--- a/tabcmd/commands/server.py
+++ b/tabcmd/commands/server.py
@@ -52,7 +52,6 @@ class Server:
         logger.debug(_("export.status").format(item_log_name))
 
         result = []
-        total_available_items = None
         page_number = 1
         total_retrieved_items = 0
 
@@ -86,12 +85,11 @@ class Server:
                     detail=_("errors.xmlapi.not_found") + ": " + item_log_name,
                 )
 
+            total_retrieved_items += len(all_items)
             # Post-filter by exact project_id when looking up non-project items within a specific container.
             # This prevents selecting a similarly named item from a sibling project that shares the same name.
             if container and type(item_endpoint).__name__.find("Projects") < 0:
                 all_items = [i for i in all_items if getattr(i, "project_id", None) == container.id]
-
-            total_retrieved_items += len(all_items)
 
             logger.debug(
                 "{} items of name: {} were found for query page number: {}, page size: {} & total available: {}".format(

--- a/tests/commands/test_server_item_selection.py
+++ b/tests/commands/test_server_item_selection.py
@@ -1,0 +1,68 @@
+import pytest
+import tableauserverclient as TSC
+
+from tabcmd.commands.server import Server
+
+
+class _Logger:
+    def debug(self, *_args, **_kwargs):
+        pass
+
+
+class _DummyItem:
+    def __init__(self, name: str, project_id: str):
+        self.name = name
+        self.project_id = project_id
+
+
+class _DummyPagination:
+    def __init__(self, total_available: int, page_number: int = 1, page_size: int = 100):
+        self.total_available = total_available
+        self.page_number = page_number
+        self.page_size = page_size
+
+
+class _DatasourcesEndpoint:
+    # Deliberately named so type(item_endpoint).__name__ == "Datasources"
+    def __init__(self, items):
+        self._items = items
+
+    def get(self, _req_option: TSC.RequestOptions):
+        # Ignore server-side filters for this unit test; we validate client-side disambiguation
+        return self._items, _DummyPagination(total_available=len(self._items))
+
+
+class _ProjectItem:
+    # Minimal project-like object carrying id/name used by Server.get_items_by_name
+    def __init__(self, project_id: str, name: str):
+        self.id = project_id
+        self.name = name
+
+
+def test_filters_datasources_by_exact_project_id_when_container_provided():
+    logger = _Logger()
+    container = _ProjectItem(project_id="proj-A", name="Shared")
+    # Two datasources with identical names, different project ownership
+    items = [
+        _DummyItem(name="Sales", project_id="proj-A"),
+        _DummyItem(name="Sales", project_id="proj-B"),
+    ]
+    endpoint = _DatasourcesEndpoint(items)
+
+    results = Server.get_items_by_name(logger, endpoint, "Sales", container)
+
+    assert len(results) == 1
+    assert results[0].project_id == "proj-A"
+
+
+def test_raises_not_found_when_no_items_match_container_after_disambiguation():
+    logger = _Logger()
+    container = _ProjectItem(project_id="proj-Z", name="Shared")
+    items = [
+        _DummyItem(name="Sales", project_id="proj-A"),
+        _DummyItem(name="Sales", project_id="proj-B"),
+    ]
+    endpoint = _DatasourcesEndpoint(items)
+
+    with pytest.raises(TSC.ServerResponseError):
+        Server.get_items_by_name(logger, endpoint, "Sales", container)

--- a/tests/commands/test_server_item_selection.py
+++ b/tests/commands/test_server_item_selection.py
@@ -66,3 +66,30 @@ def test_raises_not_found_when_no_items_match_container_after_disambiguation():
 
     with pytest.raises(TSC.ServerResponseError):
         Server.get_items_by_name(logger, endpoint, "Sales", container)
+
+
+def test_nested_projects_same_leaf_name_returns_correct_datasource_per_container():
+    logger = _Logger()
+    # Simulate three separate 'Cats' projects that exist at different levels:
+    # MyProjects/ProjectA/Cats, MyProjects/ProjectB/Cats, and MyProjects/Cats
+    cats_under_project_a = _ProjectItem(project_id="cats-A", name="Cats")
+    cats_under_project_b = _ProjectItem(project_id="cats-B", name="Cats")
+    cats_under_root = _ProjectItem(project_id="cats-root", name="Cats")
+
+    # Three datasources all named identically but owned by different 'Cats' projects
+    items = [
+        _DummyItem(name="my-datasource", project_id="cats-A"),
+        _DummyItem(name="my-datasource", project_id="cats-B"),
+        _DummyItem(name="my-datasource", project_id="cats-root"),
+    ]
+    endpoint = _DatasourcesEndpoint(items)
+
+    # Each lookup should return exactly one item from the target project id
+    res_a = Server.get_items_by_name(logger, endpoint, "my-datasource", cats_under_project_a)
+    assert len(res_a) == 1 and res_a[0].project_id == "cats-A"
+
+    res_b = Server.get_items_by_name(logger, endpoint, "my-datasource", cats_under_project_b)
+    assert len(res_b) == 1 and res_b[0].project_id == "cats-B"
+
+    res_root = Server.get_items_by_name(logger, endpoint, "my-datasource", cats_under_root)
+    assert len(res_root) == 1 and res_root[0].project_id == "cats-root"

--- a/tests/commands/test_server_item_selection.py
+++ b/tests/commands/test_server_item_selection.py
@@ -23,7 +23,6 @@ class _DummyPagination:
 
 
 class _DatasourcesEndpoint:
-    # Deliberately named so type(item_endpoint).__name__ == "Datasources"
     def __init__(self, items):
         self._items = items
 


### PR DESCRIPTION

_setup_
MyProjects/ProjectA/Cats/my-datasource 
MyProjects/ProjectB/Cats/my-datasource
MyPorjects/Cats/my-datasource

_Run:_
tabcmd refreshextracts --project "Cats" --parent-project-path "MyProjects/ProjectA" --datasource "my-datasource"
Note that this refreshes the expected data source: MyProjects/ProjectA/Cats/my-datasource
_Run:_
tabcmd refreshextracts --project "Cats" --parent-project-path "MyProjects/ProjectB" --datasource "my-datasource"
Note that this ALSO refreshes the data source: MyProjects/ProjectA/Cats/my-datasource
_Run:_
tabcmd refreshextracts --project "Cats" --parent-project-path "MyProjects" --datasource "my-datasource" --no-certcheck
Note that this ALSO refreshes the data source: MyProjects/ProjectA/Cats/my-datasource