### PR TITLE
Update to run only on currently supported python versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/run-e2-tests.yml
+++ b/.github/workflows/run-e2-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,15 +32,15 @@ authors = [{name="Tableau", email="github@tableau.com"}]
 license = "MIT"
 license-files = ["LICENSE"]
 readme = "res/README.md"
-requires-python = ">=3.9"  # https://devguide.python.org/versions/
+requires-python = ">=3.10"  # https://devguide.python.org/versions/
 classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13"
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14"
 ]
 dependencies = [
     "appdirs",

--- a/tabcmd/commands/datasources_and_workbooks/publish_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/publish_command.py
@@ -63,21 +63,21 @@ class PublishCommand(DatasourcesAndWorkbooks):
 
         publish_mode = PublishCommand.get_publish_mode(args, logger)
 
-        connection = TSC.models.ConnectionItem()
+        # Build both forms: workbook "connections" (ConnectionItem) and datasource "connection_credentials"
+        workbook_connections = None
+        datasource_credentials = None
         if args.db_username:
-            connection.connection_credentials = TSC.models.ConnectionCredentials(
-                args.db_username, args.db_password, embed=args.save_db_password
-            )
+            creds = TSC.models.ConnectionCredentials(args.db_username, args.db_password, embed=args.save_db_password)
+            workbook_connections = TSC.ConnectionItem()
+            workbook_connections.connection_credentials = creds
+            datasource_credentials = creds
         elif args.oauth_username:
-            connection.connection_credentials = TSC.models.ConnectionCredentials(
-                args.oauth_username, None, embed=False, oauth=args.save_oauth
-            )
+            creds = TSC.models.ConnectionCredentials(args.oauth_username, None, embed=False, oauth=args.save_oauth)
+            workbook_connections = TSC.ConnectionItem()
+            workbook_connections.connection_credentials = creds
+            datasource_credentials = creds
         else:
             logger.debug("No db-username or oauth-username found in command")
-            creds = None
-        credentials = TSC.ConnectionItem() if creds else None
-        if credentials:
-            credentials.connection_credentials = creds
 
         files = PublishCommand.get_files_to_publish(args, logger)
 
@@ -94,7 +94,7 @@ class PublishCommand(DatasourcesAndWorkbooks):
                         project_id=project_id,
                         str_filename=str_filename,
                         publish_mode=publish_mode,
-                        credentials=credentials,
+                        credentials=workbook_connections,
                     )
                 except Exception as e:
                     Errors.exit_with_error(logger, exception=e)
@@ -109,7 +109,7 @@ class PublishCommand(DatasourcesAndWorkbooks):
                         project_id=project_id,
                         str_filename=str_filename,
                         publish_mode=publish_mode,
-                        credentials=creds,
+                        credentials=datasource_credentials,
                     )
                 except Exception as exc:
                     Errors.exit_with_error(logger, exception=exc)

--- a/tests/assets/mock_data.py
+++ b/tests/assets/mock_data.py
@@ -93,7 +93,15 @@ def set_up_mock_server(mock_session):
     mock_server.any_item_type = getter
     mock_server.flows = getter
     mock_server.groups = getter
-    mock_server.projects = getter
+    # Ensure type name contains 'Projects' for filtering heuristics
+    class ProjectsEndpoint:
+        def __init__(self, ret):
+            self._ret = ret
+
+        def get(self, req_option):
+            return self._ret
+
+    mock_server.projects = ProjectsEndpoint(([create_fake_item()], fake_pagination))
     mock_server.sites = getter
     mock_server.users = getter
     mock_server.views = getter

--- a/tests/commands/test_publish_command.py
+++ b/tests/commands/test_publish_command.py
@@ -3,11 +3,14 @@ import unittest
 import tableauserverclient as TSC
 from ..assets import mock_data
 from unittest.mock import *
+from unittest import mock
 from tabcmd.commands.datasources_and_workbooks.publish_command import PublishCommand
+from tabcmd.commands.datasources_and_workbooks import publish_command
 
 from ..assets.mock_data import set_up_mock_args, set_up_mock_file, set_up_mock_path, set_up_mock_server
 
 mock_args = set_up_mock_args()
+mock_logger = mock.MagicMock()
 
 
 # mock the module as it is imported *when used*
@@ -83,7 +86,7 @@ class PublishCommandTests(unittest.TestCase):
         actual = PublishCommand.get_files_to_publish(mock_args, logging)
         assert actual == expected
 
-    def test_default_publish_mode(self, mock_session, mock_server):
+    def test_default_publish_mode(self, mock_path, mock_glob, mock_session):
         mock_args.replace = False
         mock_args.append = False
         mock_args.overwrite = False
@@ -91,7 +94,7 @@ class PublishCommandTests(unittest.TestCase):
         publish_mode = publish_command.PublishCommand.get_publish_mode(mock_args, mock_logger)
         self.assertEqual(publish_mode, TSC.Server.PublishMode.CreateNew)
 
-    def test_replace_publish_mode(self, mock_session, mock_server):
+    def test_replace_publish_mode(self, mock_path, mock_glob, mock_session):
         mock_args.replace = True
         mock_args.append = False
         mock_args.overwrite = False
@@ -99,7 +102,7 @@ class PublishCommandTests(unittest.TestCase):
         publish_mode = publish_command.PublishCommand.get_publish_mode(mock_args, mock_logger)
         self.assertEqual(publish_mode, TSC.Server.PublishMode.Replace)
 
-    def test_append_publish_mode(self, mock_session, mock_server):
+    def test_append_publish_mode(self, mock_path, mock_glob, mock_session):
         mock_args.replace = False
         mock_args.append = True
         mock_args.overwrite = False
@@ -107,7 +110,7 @@ class PublishCommandTests(unittest.TestCase):
         publish_mode = publish_command.PublishCommand.get_publish_mode(mock_args, mock_logger)
         self.assertEqual(publish_mode, TSC.Server.PublishMode.Append)
 
-    def test_overwrite_publish_mode(self, mock_session, mock_server):
+    def test_overwrite_publish_mode(self, mock_path, mock_glob, mock_session):
         mock_args.replace = False
         mock_args.append = False
         mock_args.overwrite = True
@@ -115,7 +118,7 @@ class PublishCommandTests(unittest.TestCase):
         publish_mode = publish_command.PublishCommand.get_publish_mode(mock_args, mock_logger)
         self.assertEqual(publish_mode, TSC.Server.PublishMode.Overwrite)
 
-    def test_invalid_combination_of_modes(self, mock_session, mock_server):
+    def test_invalid_combination_of_modes(self, mock_path, mock_glob, mock_session):
         mock_args.replace = True
         mock_args.append = True
         mock_args.overwrite = False


### PR DESCRIPTION
Since 3.9 is out of support, we introduced new typings that it doesn't have.
Also adding 3.14 to ensure we run properly on that. 