### PR TITLE
Jac/actions dependencies

### DIFF
--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -30,10 +30,11 @@ jobs:
         python --version
         python -m pip install --upgrade pip
         python -m pip install --upgrade build
-        pip install .
-        pip install .[test]
+        pip install .[versioning]
         doit version
+        pip install .
         python -m build
+        pip install .[test]
 
     #  https://github.com/marketplace/actions/pytest-coverage-comment
     - name: Generate coverage report

--- a/.github/workflows/generate-metadata.yml
+++ b/.github/workflows/generate-metadata.yml
@@ -23,9 +23,9 @@ jobs:
         python --version
         python -m pip install --upgrade pip
         python -m pip install --upgrade build
-        pip install .
-        pip install .[test]
+        pip install .[versioning]
         doit version
+        pip install .
         python -m build
 
     - name: Run license check

--- a/.github/workflows/generate-metadata.yml
+++ b/.github/workflows/generate-metadata.yml
@@ -27,6 +27,7 @@ jobs:
         doit version
         pip install .
         python -m build
+        pip install .[test]
 
     - name: Run license check
       run: python bin/license-checker.py

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -75,6 +75,7 @@ jobs:
         doit version
         pip install .
         python -m build
+        pip install .[package]
 
     - name: Package with pyinstaller for ${{matrix.TARGET}}
       run: ${{matrix.CMD_BUILD}}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -71,9 +71,9 @@ jobs:
         python --version
         python -m pip install --upgrade pip
         python -m pip install --upgrade build
-        pip install .
-        pip install .[package]
+        pip install .[versioning]
         doit version
+        pip install .
         python -m build
 
     - name: Package with pyinstaller for ${{matrix.TARGET}}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -26,10 +26,11 @@ jobs:
           python --version
           python -m pip install --upgrade pip
           python -m pip install --upgrade build
-          pip install .
-          pip install .[package]
+          pip install .[versioning]
           doit version
+          pip install .
           python -m build
+          
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ inputs.is_draft }}
         uses: pypa/gh-action-pypi-publish@release/v1  # license BSD-2

--- a/.github/workflows/run-e2-tests.yml
+++ b/.github/workflows/run-e2-tests.yml
@@ -35,10 +35,11 @@ jobs:
         python --version
         python -m pip install --upgrade pip
         python -m pip install --upgrade build
-        pip install .
-        pip install .[test]
+        pip install .[versioning]
         doit version
+        pip install .
         python -m build
+        pip install .[test]
 
     - name: Run e2e tests
       run: | 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,10 +32,11 @@ jobs:
         python --version
         python -m pip install --upgrade pip
         python -m pip install --upgrade build
-        pip install .
-        pip install .[test]
+        pip install .[versioning]
         doit version
+        pip install .
         python -m build
+        pip install .[test]
 
     - name: Test with pytest
       run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,14 +62,15 @@ test = [
     "types-appdirs",
     "types-mock",
     "types-requests",
-    "types-setuptools",
-    # these last three are required for the versioning step
+    "types-setuptools"
+]
+localize = ["doit", "ftfy"]
+package = ["doit", "pyinstaller==5.13"]
+versioning = [
     "doit",
     "pyinstaller_versionfile",
     "setuptools_scm"
 ]
-localize = ["doit", "ftfy"]
-package = ["doit", "pyinstaller==5.13"]
 [project.urls]
 repository = "https://github.com/tableau/tabcmd"
 [project.scripts]


### PR DESCRIPTION
Versioning steps were working by coincidence because we installed the required setuptools in [test]. Changed it to an explicit set of dependencies, removed the test deps where not running tests, and re-ordered the install/run steps in all actions so we should be getting explicit behavior.