### PR TITLE
docs: add quoting guide and sudo warning (#226 #45)

### DIFF
--- a/docs/tabcmd_cmd.md
+++ b/docs/tabcmd_cmd.md
@@ -8,6 +8,24 @@ You can use the following commands with the tabcmd command-line tool.
 * TOC
 {:toc}
 
+## Special characters in passwords and tokens
+
+If your password or personal access token contains special characters, the shell may interpret them before passing the value to tabcmd. Enclose the value in double quotes, or use `--password-file` to avoid shell escaping entirely.
+
+| Shell | Characters to watch for | Example |
+|-------|------------------------|---------|
+| Windows cmd | `^` `&` `\|` `<` `>` `(` `)` | Use double quotes: `--password "p^ssword"`, or double the character: `p^^ssword` |
+| PowerShell | `$` `` ` `` `"` `'` `@` | Wrap in single quotes: `--password 'p$ssword'` |
+| Unix/bash | `$` `!` `"` `` ` `` `\` spaces | Wrap in single quotes: `--password 'p$ssword'` |
+
+## Running tabcmd as root or with sudo
+
+When tabcmd is run as `root` or with `sudo` on Linux or macOS, the home directory used for the session cookie and log file will be `/root/` rather than your normal home directory. This means:
+
+- A session started as your normal user will not be visible when running as root, and vice versa.
+- Log files will be written to `/root/tabcmd.log` instead of your home directory.
+
+Avoid running tabcmd with `sudo` unless required. If you must, be aware that each user context maintains a separate session.
 
 ## login
 Logs in a Tableau user. 


### PR DESCRIPTION
## Summary

- Adds a guide explaining how to quote passwords and personal access tokens containing special characters on Windows cmd, PowerShell, and Unix/bash (#226)
- Adds a note about home directory behavior when running tabcmd as root or with sudo on Linux/macOS (#45)

## Test plan

- [ ] Review rendered output on gh-pages after merge
- [ ] Verify quoting examples are accurate for each shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)