### PR TITLE
docs: add default values table to login options

### DIFF
--- a/docs/tabcmd_cmd.md
+++ b/docs/tabcmd_cmd.md
@@ -93,6 +93,15 @@ For more information about loggin in, see [Logging in](index.html#logging-in).
 : The token specified for --token-name. If you do not provide a token, you will be prompted for one.
 
 
+### Default values
+
+| Option | Default |
+|--------|---------|
+| `--server` | `http://localhost` (port 80) — you must specify a server URL or the command will attempt to connect to localhost |
+| `--site` | Default site (empty string `""`) |
+| `--cookie` | Session ID is saved (use `--no-cookie` to disable) |
+| `--timeout` | 30 seconds |
+
 ### Example
 
 Log in to the Tableau Cloud site with the specified site ID:


### PR DESCRIPTION
## Summary

- Adds a **Default values** table to the `login` command section listing the defaults for `--server`, `--site`, `--cookie`, and `--timeout`
- Notes that `--server` defaults to `http://localhost` and that users must specify a URL, to prevent confusion (see #402)

Closes #46

## Test plan

- [ ] Verify table renders correctly on the GitHub Pages site
- [ ] Confirm defaults match actual argparse/session.py values