### PR TITLE
ci: add workflow to check i18n string keys on PRs

### DIFF
--- a/.github/workflows/check-strings.yml
+++ b/.github/workflows/check-strings.yml
@@ -1,0 +1,26 @@
+name: Check i18n strings
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - development
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  check-strings:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Check for missing i18n string keys
+      run: python bin/i18n/check_strings.py

--- a/.github/workflows/check-strings.yml
+++ b/.github/workflows/check-strings.yml
@@ -15,12 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
+    # Note: check_strings.py uses regex matching and will not catch dynamic keys
+    # (f-strings, variables, concatenation). This is a best-effort check.
     - name: Check for missing i18n string keys
       run: python bin/i18n/check_strings.py


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/check-strings.yml` that runs `bin/i18n/check_strings.py` on every PR targeting `development` or `main`
- Fails the PR if any `_("some.key")` call in `tabcmd/` has no matching entry in `tabcmd/locales/en/*.properties`
- Single job (ubuntu-latest, Python 3.12) — no matrix needed, this is a pure text scan with no external dependencies

## Notes

- The script uses regex matching and will not catch dynamically-constructed keys (f-strings, variable keys, concatenation) — best-effort guardrail
- Verified the script currently exits 0 on `development` so this gate will not be immediately red

## Test plan

- [ ] Confirm workflow appears in Actions tab after merge
- [ ] Open a test PR that adds `_("missing.key")` to a source file without updating properties — verify workflow fails
- [ ] Confirm existing PRs (#404–#408) would pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)