### PR TITLE
fix: make python -m tabcmd work reliably (#375)

### DIFF
--- a/tabcmd/__main__.py
+++ b/tabcmd/__main__.py
@@ -3,15 +3,19 @@ import sys
 try:
     from tabcmd.tabcmd import main
 except ImportError as e:
-    print("Exception thrown running program: `{}`, `{}`".format(e, e.__context__), file=sys.stderr)
-
+    print(
+        "Exception thrown importing tabcmd: `{}`, `{}`".format(e, e.__context__),
+        file=sys.stderr,
+    )
     if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
         print("Application is running in an executable bundle")
         print("sys.argv[0] is", sys.argv[0])
         print("sys.executable is", sys.executable)
     else:
-        print("[Possible cause: Tabcmd needs to be run as a module, try running `python -m tabcmd`]", file=sys.stderr)
+        print(
+            "[Possible cause: Tabcmd needs to be installed, try `pip install tabcmd`]",
+            file=sys.stderr,
+        )
+    sys.exit(1)
 
-
-if __name__ == "__main__":
-    main()
+main()

--- a/tabcmd/__main__.py
+++ b/tabcmd/__main__.py
@@ -2,18 +2,16 @@ import sys
 
 try:
     from tabcmd.tabcmd import main
-except ImportError as e:
-    print(
-        "Exception thrown importing tabcmd: `{}`, `{}`".format(e, e.__context__),
-        file=sys.stderr,
-    )
+except Exception as e:
+    ctx = ", caused by: {}".format(e.__context__) if e.__context__ else ""
+    print("Exception thrown importing tabcmd: {}{}".format(e, ctx), file=sys.stderr)
     if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
         print("Application is running in an executable bundle", file=sys.stderr)
         print("sys.argv[0] is", sys.argv[0], file=sys.stderr)
         print("sys.executable is", sys.executable, file=sys.stderr)
     else:
         print(
-            "[Possible cause: Tabcmd needs to be installed, try `pip install tabcmd`]",
+            "[Possible cause: tabcmd is installed but broken, try `pip install --force-reinstall tabcmd`]",
             file=sys.stderr,
         )
     sys.exit(1)

--- a/tabcmd/__main__.py
+++ b/tabcmd/__main__.py
@@ -8,9 +8,9 @@ except ImportError as e:
         file=sys.stderr,
     )
     if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
-        print("Application is running in an executable bundle")
-        print("sys.argv[0] is", sys.argv[0])
-        print("sys.executable is", sys.executable)
+        print("Application is running in an executable bundle", file=sys.stderr)
+        print("sys.argv[0] is", sys.argv[0], file=sys.stderr)
+        print("sys.executable is", sys.executable, file=sys.stderr)
     else:
         print(
             "[Possible cause: Tabcmd needs to be installed, try `pip install tabcmd`]",
@@ -18,4 +18,6 @@ except ImportError as e:
         )
     sys.exit(1)
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+import unittest
+
+
+class TestPythonMTabcmd(unittest.TestCase):
+    def test_python_m_tabcmd_no_args_exits_zero(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tabcmd"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, msg=f"stderr: {result.stderr}\nstdout: {result.stdout}")
+
+    def test_python_m_tabcmd_help_exits_zero(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tabcmd", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, msg=f"stderr: {result.stderr}\nstdout: {result.stdout}")
+        self.assertIn("tabcmd", result.stdout)
+
+    def test_python_m_tabcmd_help_subcommand_exits_zero(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tabcmd", "help"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, msg=f"stderr: {result.stderr}\nstdout: {result.stdout}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,7 @@
+import os
 import subprocess
 import sys
+import tempfile
 import unittest
 
 
@@ -9,6 +11,7 @@ class TestPythonMTabcmd(unittest.TestCase):
             [sys.executable, "-m", "tabcmd"],
             capture_output=True,
             text=True,
+            timeout=30,
         )
         self.assertEqual(result.returncode, 0, msg=f"stderr: {result.stderr}\nstdout: {result.stdout}")
 
@@ -17,17 +20,51 @@ class TestPythonMTabcmd(unittest.TestCase):
             [sys.executable, "-m", "tabcmd", "--help"],
             capture_output=True,
             text=True,
+            timeout=30,
         )
         self.assertEqual(result.returncode, 0, msg=f"stderr: {result.stderr}\nstdout: {result.stdout}")
-        self.assertIn("tabcmd", result.stdout)
+        self.assertIn("usage:", result.stdout.lower())
 
     def test_python_m_tabcmd_help_subcommand_exits_zero(self):
         result = subprocess.run(
             [sys.executable, "-m", "tabcmd", "help"],
             capture_output=True,
             text=True,
+            timeout=30,
         )
         self.assertEqual(result.returncode, 0, msg=f"stderr: {result.stderr}\nstdout: {result.stdout}")
+
+    def test_import_error_exits_one(self):
+        # Build a minimal fake tabcmd package in a temp directory.
+        # Running python -m tabcmd from that directory makes the fake package
+        # take precedence ('' is first on sys.path), so tabcmd.tabcmd raises
+        # ImportError and __main__.py must catch it, print the error, and exit 1.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_pkg = os.path.join(tmpdir, "tabcmd")
+            os.makedirs(fake_pkg, exist_ok=True)
+            # __init__.py — empty, makes it a package
+            open(os.path.join(fake_pkg, "__init__.py"), "w").close()
+            # tabcmd.py — raises ImportError on import
+            with open(os.path.join(fake_pkg, "tabcmd.py"), "w") as f:
+                f.write('raise ImportError("test error")\n')
+            # __main__.py — copy of the real entry-point so -m tabcmd works
+            real_main = os.path.join(os.path.dirname(__file__), "..", "tabcmd", "__main__.py")
+            with open(real_main) as src, open(os.path.join(fake_pkg, "__main__.py"), "w") as dst:
+                dst.write(src.read())
+
+            # Strip PYTHONPATH so the installed package cannot interfere
+            env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+
+            result = subprocess.run(
+                [sys.executable, "-m", "tabcmd"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=tmpdir,
+                env=env,
+            )
+        self.assertEqual(result.returncode, 1, msg=f"stderr: {result.stderr}\nstdout: {result.stdout}")
+        self.assertIn("Exception thrown importing tabcmd", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,7 +2,16 @@ import os
 import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _repo_env():
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _REPO_ROOT
+    return env
 
 
 class TestPythonMTabcmd(unittest.TestCase):
@@ -12,8 +21,9 @@ class TestPythonMTabcmd(unittest.TestCase):
             capture_output=True,
             text=True,
             timeout=30,
+            env=_repo_env(),
         )
-        self.assertEqual(result.returncode, 0, msg=f"stderr: {result.stderr}\nstdout: {result.stdout}")
+        self.assertEqual(result.returncode, 0, msg="stderr: {}\nstdout: {}".format(result.stderr, result.stdout))
 
     def test_python_m_tabcmd_help_exits_zero(self):
         result = subprocess.run(
@@ -21,8 +31,9 @@ class TestPythonMTabcmd(unittest.TestCase):
             capture_output=True,
             text=True,
             timeout=30,
+            env=_repo_env(),
         )
-        self.assertEqual(result.returncode, 0, msg=f"stderr: {result.stderr}\nstdout: {result.stdout}")
+        self.assertEqual(result.returncode, 0, msg="stderr: {}\nstdout: {}".format(result.stderr, result.stdout))
         self.assertIn("usage:", result.stdout.lower())
 
     def test_python_m_tabcmd_help_subcommand_exits_zero(self):
@@ -31,39 +42,36 @@ class TestPythonMTabcmd(unittest.TestCase):
             capture_output=True,
             text=True,
             timeout=30,
+            env=_repo_env(),
         )
-        self.assertEqual(result.returncode, 0, msg=f"stderr: {result.stderr}\nstdout: {result.stdout}")
+        self.assertEqual(result.returncode, 0, msg="stderr: {}\nstdout: {}".format(result.stderr, result.stdout))
 
     def test_import_error_exits_one(self):
-        # Build a minimal fake tabcmd package in a temp directory.
-        # Running python -m tabcmd from that directory makes the fake package
-        # take precedence ('' is first on sys.path), so tabcmd.tabcmd raises
-        # ImportError and __main__.py must catch it, print the error, and exit 1.
+        # Inject a broken tabcmd.tabcmd into sys.modules before running __main__,
+        # so the ImportError handler is exercised without relying on sys.path ordering.
+        script = textwrap.dedent(
+            """\
+            import sys
+            class _BrokenTabcmd:
+                def __getattr__(self, _):
+                    raise ImportError("injected failure")
+            sys.modules["tabcmd.tabcmd"] = _BrokenTabcmd()
+            import runpy
+            runpy.run_module("tabcmd", run_name="__main__")
+            """
+        )
         with tempfile.TemporaryDirectory() as tmpdir:
-            fake_pkg = os.path.join(tmpdir, "tabcmd")
-            os.makedirs(fake_pkg, exist_ok=True)
-            # __init__.py — empty, makes it a package
-            open(os.path.join(fake_pkg, "__init__.py"), "w").close()
-            # tabcmd.py — raises ImportError on import
-            with open(os.path.join(fake_pkg, "tabcmd.py"), "w") as f:
-                f.write('raise ImportError("test error")\n')
-            # __main__.py — copy of the real entry-point so -m tabcmd works
-            real_main = os.path.join(os.path.dirname(__file__), "..", "tabcmd", "__main__.py")
-            with open(real_main) as src, open(os.path.join(fake_pkg, "__main__.py"), "w") as dst:
-                dst.write(src.read())
-
-            # Strip PYTHONPATH so the installed package cannot interfere
-            env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
-
+            script_path = os.path.join(tmpdir, "run.py")
+            with open(script_path, "w") as f:
+                f.write(script)
             result = subprocess.run(
-                [sys.executable, "-m", "tabcmd"],
+                [sys.executable, script_path],
                 capture_output=True,
                 text=True,
                 timeout=30,
-                cwd=tmpdir,
-                env=env,
+                env=_repo_env(),
             )
-        self.assertEqual(result.returncode, 1, msg=f"stderr: {result.stderr}\nstdout: {result.stdout}")
+        self.assertEqual(result.returncode, 1, msg="stderr: {}\nstdout: {}".format(result.stderr, result.stdout))
         self.assertIn("Exception thrown importing tabcmd", result.stderr)
 
 


### PR DESCRIPTION
## Summary

- Fixes #375
- Restores `if __name__ == "__main__":` guard (removed guard would call `sys.exit()` on any `import tabcmd.__main__`)
- Adds `sys.exit(1)` in the import-failure handler so the process exits non-zero instead of crashing on `main()` being undefined
- Broadens `except ImportError` to `except Exception` — broken installs can also raise `SyntaxError`, `OSError` (missing `.mo` files), `AttributeError`
- Makes `e.__context__` conditional (was always printing `None` for top-level import failures)
- Improves error message to suggest `--force-reinstall` (tabcmd is already on `sys.path` when this fires)
- Routes all diagnostic prints in the frozen-bundle path to `stderr`
- Adds `tests/test_main.py` with subprocess-based tests; import-error test uses `sys.modules` injection instead of fragile CWD/path ordering; success tests pass `PYTHONPATH` explicitly

## Test plan
- [ ] `python -m pytest tests/test_main.py -v` — 4 tests pass
- [ ] `python -m pytest tests/ --ignore=tests/e2e` — full suite passes
- [ ] `python -m tabcmd` exits 0
- [ ] `python -m tabcmd --help` exits 0 and prints usage
- [ ] Broken install path: exits 1 with "Exception thrown importing tabcmd" on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)