### PR TITLE
fix: correct :size=W,H argument order in URL params (#349)

### DIFF
--- a/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/datasources_and_workbooks_command.py
@@ -83,7 +83,7 @@ class DatasourcesAndWorkbooks(Server):
                     DatasourcesAndWorkbooks.apply_encoded_filter_value(logger, request_options, value)
 
         except Exception as e:
-            logger.warn("Error building filter params", e)
+            logger.warning("Error building filter params: %s", e)
             # ExportCommand.log_stack(logger)  # type: ignore
 
     # this is called from within from_url_params, for each view_filter value
@@ -114,7 +114,7 @@ class DatasourcesAndWorkbooks(Server):
         logger.debug("handling url option {}".format(value))
         setting = value.split("=")
         if len(setting) != 2:
-            logger.warn("Unable to read url parameter '{}', skipping".format(value))
+            logger.warning("Unable to read url parameter '{}', skipping".format(value))
             return
         setting_name = setting[0]
         setting_val = setting[1]
@@ -129,12 +129,12 @@ class DatasourcesAndWorkbooks(Server):
         elif ":size" == setting_name:
             if isinstance(request_options, (TSC.ImageRequestOptions, TSC.PDFRequestOptions)):
                 try:
-                    height, width = setting_val.split(",")
-                    request_options.viz_height = int(height)
-                    request_options.viz_width = int(width)
+                    width, height = setting_val.split(",")
+                    w_int, h_int = int(width), int(height)
+                    request_options.viz_width = w_int
+                    request_options.viz_height = h_int
                 except Exception as oops:
-                    logger.warn("Unable to read image size options '{}', skipping".format(setting_val))
-                    logger.warn(oops)
+                    logger.warning("Unable to read image size options: %s", oops)
             else:
                 logger.debug(
                     "Request options are not of type ImageRequestOptions or PDFRequestOptions, skipping size setting"

--- a/tests/commands/test_datasources_and_workbooks_command.py
+++ b/tests/commands/test_datasources_and_workbooks_command.py
@@ -133,8 +133,8 @@ class ParameterTests(unittest.TestCase):
         value = ":size=800,600"
 
         DatasourcesAndWorkbooks.apply_options_in_url(mock_logger, request_options, value)
-        self.assertEqual(request_options.viz_height, 800)
-        self.assertEqual(request_options.viz_width, 600)
+        self.assertEqual(request_options.viz_width, 800)  # first value is width
+        self.assertEqual(request_options.viz_height, 600)  # second value is height
 
     def test_apply_options_in_url_with_refresh(self):
         request_options = tsc.ImageRequestOptions()
@@ -150,6 +150,13 @@ class ParameterTests(unittest.TestCase):
         DatasourcesAndWorkbooks.apply_options_in_url(mock_logger, request_options, value)
         self.assertEqual(request_options.viz_height, None)
         self.assertEqual(request_options.viz_width, None)
+
+    def test_apply_options_in_url_with_partial_size_no_partial_state(self):
+        # if the first dimension is invalid, neither width nor height should be set
+        request_options = tsc.ImageRequestOptions()
+        DatasourcesAndWorkbooks.apply_options_in_url(mock_logger, request_options, ":size=notanumber,600")
+        self.assertIsNone(request_options.viz_width)
+        self.assertIsNone(request_options.viz_height)
 
     def test_apply_options_in_url_with_unrecognized_parameter(self):
         request_options = tsc.ImageRequestOptions()

--- a/tests/commands/test_datasources_and_workbooks_command.py
+++ b/tests/commands/test_datasources_and_workbooks_command.py
@@ -130,11 +130,15 @@ class ParameterTests(unittest.TestCase):
 
     def test_apply_options_in_url_with_size(self):
         request_options = tsc.ImageRequestOptions()
-        value = ":size=800,600"
+        DatasourcesAndWorkbooks.apply_options_in_url(mock_logger, request_options, ":size=1920,1080")
+        self.assertEqual(request_options.viz_width, 1920)
+        self.assertEqual(request_options.viz_height, 1080)
 
-        DatasourcesAndWorkbooks.apply_options_in_url(mock_logger, request_options, value)
-        self.assertEqual(request_options.viz_width, 800)  # first value is width
-        self.assertEqual(request_options.viz_height, 600)  # second value is height
+    def test_apply_options_in_url_with_size_via_url_params(self):
+        request_options = tsc.ImageRequestOptions()
+        DatasourcesAndWorkbooks.apply_values_from_url_params(mock_logger, request_options, "?:size=1920,1080")
+        self.assertEqual(request_options.viz_width, 1920)
+        self.assertEqual(request_options.viz_height, 1080)
 
     def test_apply_options_in_url_with_refresh(self):
         request_options = tsc.ImageRequestOptions()
@@ -151,10 +155,15 @@ class ParameterTests(unittest.TestCase):
         self.assertEqual(request_options.viz_height, None)
         self.assertEqual(request_options.viz_width, None)
 
-    def test_apply_options_in_url_with_partial_size_no_partial_state(self):
-        # if the first dimension is invalid, neither width nor height should be set
+    def test_apply_options_in_url_invalid_first_dimension_leaves_both_unset(self):
         request_options = tsc.ImageRequestOptions()
         DatasourcesAndWorkbooks.apply_options_in_url(mock_logger, request_options, ":size=notanumber,600")
+        self.assertIsNone(request_options.viz_width)
+        self.assertIsNone(request_options.viz_height)
+
+    def test_apply_options_in_url_invalid_second_dimension_leaves_both_unset(self):
+        request_options = tsc.ImageRequestOptions()
+        DatasourcesAndWorkbooks.apply_options_in_url(mock_logger, request_options, ":size=1920,notanumber")
         self.assertIsNone(request_options.viz_width)
         self.assertIsNone(request_options.viz_height)
 


### PR DESCRIPTION
## Summary

- Fixes #349
- `get` with `:size=800,600` in the URL was setting `viz_height=800, viz_width=600` (transposed from tabcmd 1 behavior)
- Swaps the unpacking: `width, height = setting_val.split(",")` (was `height, width`)
- Converts both dimensions to int before assigning either, so a parse failure on either value leaves both `viz_width` and `viz_height` as `None` (no partial state)
- Replaces deprecated `logger.warn(...)` with `logger.warning(...)` — the old call also had a latent bug where the exception argument was never rendered into the log line
- Strengthens tests: asymmetric values (`1920,1080`) make swap direction self-evident; adds test for invalid second dimension leaving both unset; adds integration test through `apply_values_from_url_params`

## Test plan
- [ ] `python -m pytest tests/commands/test_datasources_and_workbooks_command.py -v` — 25 tests pass
- [ ] `tabcmd get "workbook/view?:size=1920,1080" -f out.png` produces a 1920×1080 image

🤖 Generated with [Claude Code](https://claude.com/claude-code)