### PR TITLE
fix: point dependabot at development branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,14 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    # Raise pull requests for version updates to pip against the `develop` branch
-    target-branch: "develop"
+  - package-ecosystem: "pip"
+    directory: "/"
+    target-branch: "development"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary
- `pip` ecosystem was targeting `develop` (a branch that doesn't exist), so pip dependency PRs were never being created
- `github-actions` ecosystem had no `target-branch`, so it defaulted to `main` — this is why the recent actions/checkout and actions/upload-artifact bumps landed directly on `main` instead of going through `development`
- Both now target `development`

## Test plan
- [ ] Verify next weekly dependabot run creates PRs against `development`

🤖 Generated with [Claude Code](https://claude.com/claude-code)