### PR TITLE
ci: trigger PyPI smoke tests after publish workflow completes

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -3,11 +3,13 @@
 
 name: Pypi smoke tests
 
-# maybe we want this triggered after the publish-pypi workflow?
 on:
   workflow_dispatch:
   schedule:
     - cron: 0 11 * * * # Every day at 11AM UTC (7AM EST)
+  workflow_run:
+    workflows: ["Publish to PyPi"]
+    types: [completed]
 
 permissions:
   contents: read

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Adds `workflow_run` trigger so smoke tests fire automatically whenever `Publish to PyPi` completes
- Keeps existing daily schedule and manual dispatch

Note: `workflow_run` fires regardless of publish success or failure — add an `if: github.event.workflow_run.conclusion == 'success'` on the job if you want to skip on failed publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)