### PR TITLE
ci: bump actions/checkout to v7 in check-strings workflow

### DIFF
--- a/.github/workflows/check-strings.yml
+++ b/.github/workflows/check-strings.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Set up Python
       uses: actions/setup-python@v6


### PR DESCRIPTION
Keeps action pins consistent with the other workflows, which already use checkout@v7.