### PR TITLE
security: add environment gate to production PyPI publish job

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,6 +14,7 @@ jobs:
   build-n-publish:
     name: Build dist files for PyPi
     runs-on: ubuntu-latest
+    environment: pypi
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Adds `environment: pypi` to the `build-n-publish` job in `.github/workflows/publish-pypi.yml`.

Without this, any repo write holder can invoke `workflow_dispatch` or publish a release and the production PyPI publish runs immediately with no human checkpoint. The `pypi` GitHub Environment is already configured on this repo with required reviewers (`tableau/devplat`), `can_admins_bypass: false`, and `prevent_self_review: true` — this change wires the job to it.

No logic changes — one line added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)