### PR TITLE
feat: allow repeated --filter flags for exports

### DIFF
--- a/tabcmd/commands/datasources_and_workbooks/export_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/export_command.py
@@ -68,6 +68,7 @@ class ExportCommand(DatasourcesAndWorkbooks):
         group.add_argument(
             "--filter",
             metavar="COLUMN=VALUE",
+            action="append",
             help=_("tabcmd.export.help.filter"),
         )
         group.add_argument(
@@ -143,11 +144,19 @@ class ExportCommand(DatasourcesAndWorkbooks):
 
     @staticmethod
     def apply_filters_from_args(request_options: RequestOptionsType, args, logger=None) -> None:
-        if args.filter:
-            logger.debug("filter = {}".format(args.filter))
-            params = args.filter.split("&")
-            for value in params:
-                ExportCommand.apply_filter_value(logger, request_options, value)
+        if not args.filter:
+            return
+        logger.debug("filter = {}".format(args.filter))
+        # Back-compat: a single --filter flag historically joined multiple pairs
+        # with '&' (e.g. `--filter "a=1&b=2"`), so that one case still splits on '&'.
+        # Repeated --filter flags each carry exactly one pair — no split — so a
+        # literal '&' or '=' in a value is passed through untouched.
+        if len(args.filter) == 1:
+            values = args.filter[0].split("&")
+        else:
+            values = args.filter
+        for value in values:
+            ExportCommand.apply_filter_value(logger, request_options, value)
 
     @staticmethod
     def download_wb_pdf(server, workbook_item, args, logger):

--- a/tabcmd/commands/datasources_and_workbooks/export_command.py
+++ b/tabcmd/commands/datasources_and_workbooks/export_command.py
@@ -143,7 +143,7 @@ class ExportCommand(DatasourcesAndWorkbooks):
             Errors.exit_with_error(logger, "Error saving to file", exception=e)
 
     @staticmethod
-    def apply_filters_from_args(request_options: RequestOptionsType, args, logger=None) -> None:
+    def apply_filters_from_args(request_options: RequestOptionsType, args, logger) -> None:
         if not args.filter:
             return
         logger.debug("filter = {}".format(args.filter))

--- a/tabcmd/locales/en/tabcmd_messages_en.properties
+++ b/tabcmd/locales/en/tabcmd_messages_en.properties
@@ -155,7 +155,7 @@ tabcmd.error.server_connection_failed=Failed to connect to server
 tabcmd.errors.parent.not.found=Containing project could not be found
 tabcmd.errors.user_already_exists=A user with the name {0} already exists. Try a different name.
 tabcmd.export.help.filename=Filename to store the exported data
-tabcmd.export.help.filter=Data filter to apply to the view
+tabcmd.export.help.filter=Data filter to apply to the view (COLUMN=VALUE). Repeat the flag for multiple filters (--filter "A=1" --filter "B=2"); repeated flags allow '&' inside a value. For back-compat, a single --filter may still join pairs with '&' (--filter "A=1&B=2").
 tabcmd.export.help.orientation=Page orientation (landscape or portrait) of the exported PDF
 tabcmd.export.help.page_size=Set the page size of the exported PDF
 tabcmd.export.help.url=URL of the workbook or view to export

--- a/tests/commands/test_datasources_and_workbooks_command.py
+++ b/tests/commands/test_datasources_and_workbooks_command.py
@@ -2,6 +2,7 @@ import argparse
 from unittest.mock import MagicMock
 
 from tabcmd.commands.datasources_and_workbooks.datasources_and_workbooks_command import DatasourcesAndWorkbooks
+from tabcmd.commands.datasources_and_workbooks.export_command import ExportCommand
 import tableauserverclient as tsc
 import unittest
 from unittest import mock
@@ -188,6 +189,32 @@ class ParameterTests(unittest.TestCase):
         request_options = tsc.CSVRequestOptions()
         DatasourcesAndWorkbooks.apply_csv_options(mock_logger, request_options, mock_args)
         assert request_options.language == "de"
+
+    def test_apply_filters_from_args_none(self):
+        args = argparse.Namespace(filter=None)
+        request_options = tsc.PDFRequestOptions()
+        ExportCommand.apply_filters_from_args(request_options, args, mock_logger)
+        assert request_options.view_filters == []
+
+    def test_apply_filters_from_args_single(self):
+        args = argparse.Namespace(filter=["Region=West"])
+        request_options = tsc.PDFRequestOptions()
+        ExportCommand.apply_filters_from_args(request_options, args, mock_logger)
+        assert request_options.view_filters == [("Region", "West")]
+
+    def test_apply_filters_from_args_repeated(self):
+        # repeated --filter flags each carry one pair, so '&' in a value is safe.
+        args = argparse.Namespace(filter=["Region=West", "Product=AT&T"])
+        request_options = tsc.PDFRequestOptions()
+        ExportCommand.apply_filters_from_args(request_options, args, mock_logger)
+        assert request_options.view_filters == [("Region", "West"), ("Product", "AT&T")]
+
+    def test_apply_filters_from_args_backcompat_ampersand_join(self):
+        # Old-style single flag joining pairs with '&' still parses.
+        args = argparse.Namespace(filter=["Region=West&Product=Widget"])
+        request_options = tsc.PDFRequestOptions()
+        ExportCommand.apply_filters_from_args(request_options, args, mock_logger)
+        assert request_options.view_filters == [("Region", "West"), ("Product", "Widget")]
 
 
 @mock.patch("tableauserverclient.Server")

--- a/tests/parsers/test_parser_export.py
+++ b/tests/parsers/test_parser_export.py
@@ -21,3 +21,17 @@ class ExportParserTest(ParserTest):
         mock_args = [commandname]
         with self.assertRaises(SystemExit):
             args = self.parser_under_test.parse_args(mock_args)
+
+    def test_export_parser_single_filter(self):
+        args = self.parser_under_test.parse_args([commandname, "helloworld", "--pdf", "--filter", "Region=West"])
+        assert args.filter == ["Region=West"]
+
+    def test_export_parser_repeated_filter(self):
+        args = self.parser_under_test.parse_args(
+            [commandname, "helloworld", "--pdf", "--filter", "Region=West", "--filter", "Product=AT&T"]
+        )
+        assert args.filter == ["Region=West", "Product=AT&T"]
+
+    def test_export_parser_no_filter_defaults_to_none(self):
+        args = self.parser_under_test.parse_args([commandname, "helloworld", "--pdf"])
+        assert args.filter is None


### PR DESCRIPTION
## Motivation

`--filter` previously accepted one value and required multi-pair filters
to be joined with `&`. That parsing scheme prevents literal `&` inside a
value (e.g. `Product Name=AT&T` gets split). Making `--filter`
repeatable removes the need for callers to encode delimiters.

Related to #442, which handles the same problem when the filter comes in
via URL syntax rather than the flag.

## Behavior change

**For users:** `--filter` is now repeatable. Each flag carries exactly
one `COLUMN=VALUE` pair.

```
--filter "Region=West&Product=Widget"                # still works (back-compat)
--filter "Region=West" --filter "Product=Widget"     # preferred
--filter "Product=AT&T"                              # new: repeated form allows '&' in value
```

Back-compat: when only one `--filter` is present, the value is still
split on `&`. This means a single flag carrying one filter with `&` in
its value (e.g. `--filter "Product=AT&T"` alone) is still ambiguous.
Workaround: pass the filter in the URL query string instead of via
`--filter`. #442 landed the URL-path handling for literal `&`, so
`tabcmd get "views/View/Sheet.csv?Product%20Name=AT&T%20841000%20Phone"`
works correctly (space must be encoded as `%20`; `&` may be literal).

## Test plan

- [x] `pytest tests/commands/test_datasources_and_workbooks_command.py
  tests/parsers/test_parser_export.py` — 34 passed
- [x] Manual e2e: repeated `--filter` with `&` in the value returns the
  expected row
- [x] Manual e2e: single-flag `&`-joined form still parses and filters
  correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)