### PR TITLE
Fix #435: add --role/-r to creategroup

### DIFF
--- a/tabcmd/commands/group/create_group_command.py
+++ b/tabcmd/commands/group/create_group_command.py
@@ -3,6 +3,7 @@ import tableauserverclient as TSC
 from tabcmd.commands.auth.session import Session
 from tabcmd.commands.constants import Errors
 from tabcmd.commands.server import Server
+from tabcmd.commands.user.user_data import UserCommand
 from tabcmd.execution.localize import _
 from tabcmd.execution.logger_config import log
 
@@ -19,6 +20,7 @@ class CreateGroupCommand(Server):
     def define_args(create_group_parser):
         args_group = create_group_parser.add_argument_group(title=CreateGroupCommand.name)
         args_group.add_argument("name")
+        UserCommand.set_role_arg(args_group)
 
     @classmethod
     def run_command(cls, args):
@@ -29,6 +31,10 @@ class CreateGroupCommand(Server):
         try:
             logger.info(_("creategroup.status").format(args.name))
             new_group = TSC.GroupItem(args.name)
+            if getattr(args, "role", None):
+                # Classic parity: --role/-r sets the group's default site role, so
+                # users added later without an explicit role inherit this one.
+                new_group.minimum_site_role = args.role
             server.groups.create(new_group)
             logger.info(_("common.output.succeeded"))
         except Exception as e:

--- a/tests/parsers/test_parser_create_group.py
+++ b/tests/parsers/test_parser_create_group.py
@@ -20,3 +20,19 @@ class CreateGroupParserTest(ParserTest):
         mock_args = [commandname]
         with self.assertRaises(SystemExit):
             self.parser_under_test.parse_args(mock_args)
+
+    def test_creategroup_parser_role_flag(self):
+        args = self.parser_under_test.parse_args([commandname, "name", "--role", "Viewer"])
+        assert args.role == "Viewer"
+
+    def test_creategroup_parser_role_short_flag(self):
+        args = self.parser_under_test.parse_args([commandname, "name", "-r", "Explorer"])
+        assert args.role == "Explorer"
+
+    def test_creategroup_parser_role_case_insensitive(self):
+        args = self.parser_under_test.parse_args([commandname, "name", "--role", "creator"])
+        assert args.role == "Creator"
+
+    def test_creategroup_parser_role_optional(self):
+        args = self.parser_under_test.parse_args([commandname, "name"])
+        assert args.role is None


### PR DESCRIPTION
Closes #435.

## Motivation

tabcmd Classic accepts `--role`/`-r` on `creategroup` to set a default
site role for the group; users added later without an explicit role
inherit that default. tabcmd 2 was missing the flag, so groups always
got created with no `minimum_site_role`. Classic-parity gap for anyone
managing groups via scripts.

## Behavior change

**For users:** `--role`/`-r` accepted on `creategroup`. Sets
`GroupItem.minimum_site_role` before `server.groups.create` when
supplied. Reuses `UserCommand.set_role_arg` for choices and
case-insensitive parsing, matching sibling user commands.

## Test plan

- [x] `tests/parsers/test_parser_create_group.py` — 4 new tests:
  `--role Viewer`, `-r Explorer`, case-insensitive `creator` ->
  `Creator`, flag-optional
- [x] Full `test_parser_create_group.py` suite: 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)