### PR TITLE
fix: accept yes/no on --encrypt for Classic parity

### DIFF
--- a/tabcmd/execution/global_options.py
+++ b/tabcmd/execution/global_options.py
@@ -111,11 +111,32 @@ def set_embedded_datasources_options(parser):
 
 
 # used in create extract. listed in delete-extract but makes no sense there
+def _parse_yes_no(value: str) -> bool:
+    # tabcmd Classic accepted "yes"/"no"/"true"/"false" on --encrypt; tabcmd 2
+    # kept the flag but silently ignored a following value. Accept the Classic
+    # forms so scripts port cleanly.
+    lowered = value.strip().lower()
+    if lowered in ("yes", "true", "1"):
+        return True
+    if lowered in ("no", "false", "0"):
+        return False
+    import argparse
+    raise argparse.ArgumentTypeError(
+        "Expected yes/no/true/false for --encrypt, got {!r}".format(value)
+    )
+
+
 def set_encryption_option(parser):
     parser.add_argument(
         "--encrypt",
         dest="encrypt",
-        action="store_true",  # set to true IF user passes in option --encrypt
+        # Classic parity: --encrypt yes / --encrypt no. Bare --encrypt still
+        # means True (default tabcmd 2 behavior). Omitted -> False.
+        nargs="?",
+        const=True,
+        default=False,
+        type=_parse_yes_no,
+        metavar="yes|no",
         help=_("createextracts.options.encrypt"),
     )
     return parser

--- a/tabcmd/execution/global_options.py
+++ b/tabcmd/execution/global_options.py
@@ -121,9 +121,8 @@ def _parse_yes_no(value: str) -> bool:
     if lowered in ("no", "false", "0"):
         return False
     import argparse
-    raise argparse.ArgumentTypeError(
-        "Expected yes/no/true/false for --encrypt, got {!r}".format(value)
-    )
+
+    raise argparse.ArgumentTypeError("Expected yes/no/true/false for --encrypt, got {!r}".format(value))
 
 
 def set_encryption_option(parser):

--- a/tests/parsers/test_parser_create_extracts.py
+++ b/tests/parsers/test_parser_create_extracts.py
@@ -106,3 +106,39 @@ class CreateExtractsParserTest(ParserTest):
         ]
         with self.assertRaises(SystemExit):
             args = self.parser_under_test.parse_args(mock_args)
+
+    # --encrypt Classic-parity: accepts yes|no|true|false, bare flag still True, omitted False
+    def _base_args(self):
+        return [commandname, "--datasource", "ds", "--project", "p", "--parent-project-path", "pp"]
+
+    def test_encrypt_omitted_is_false(self):
+        args = self.parser_under_test.parse_args(self._base_args())
+        assert args.encrypt is False, args
+
+    def test_encrypt_bare_flag_is_true(self):
+        args = self.parser_under_test.parse_args(self._base_args() + ["--encrypt"])
+        assert args.encrypt is True, args
+
+    def test_encrypt_yes_is_true(self):
+        args = self.parser_under_test.parse_args(self._base_args() + ["--encrypt", "yes"])
+        assert args.encrypt is True, args
+
+    def test_encrypt_no_is_false(self):
+        args = self.parser_under_test.parse_args(self._base_args() + ["--encrypt", "no"])
+        assert args.encrypt is False, args
+
+    def test_encrypt_true_is_true(self):
+        args = self.parser_under_test.parse_args(self._base_args() + ["--encrypt", "true"])
+        assert args.encrypt is True, args
+
+    def test_encrypt_false_is_false(self):
+        args = self.parser_under_test.parse_args(self._base_args() + ["--encrypt", "false"])
+        assert args.encrypt is False, args
+
+    def test_encrypt_case_insensitive(self):
+        args = self.parser_under_test.parse_args(self._base_args() + ["--encrypt", "YES"])
+        assert args.encrypt is True, args
+
+    def test_encrypt_bad_value_rejected(self):
+        with self.assertRaises(SystemExit):
+            self.parser_under_test.parse_args(self._base_args() + ["--encrypt", "maybe"])


### PR DESCRIPTION
## Motivation

tabcmd Classic's `--encrypt` on `createextracts` takes an explicit
`yes` or `no` value. tabcmd 2 treated it as a bare boolean flag,
silently ignoring any following value. Scripts passing `--encrypt no`
on Classic didn't fail on tabcmd 2 but produced the wrong behavior
(they either bailed on argparse or silently kept encryption on).

## Behavior change

**For users:** `--encrypt` accepts an optional `yes|no|true|false`
argument (case-insensitive).

- Bare `--encrypt` still means `True` (tabcmd 2 syntax).
- Omitted means `False`.
- Explicit `--encrypt no` (or `false`/`0`) now means `False`.

Preserves tabcmd 2's current default while accepting Classic's
yes/no syntax.

## Test plan

- [x] `tests/parsers/test_parser_create_extracts.py` — 8 new tests:
  omitted / bare / yes / no / true / false / case-insensitive /
  bad-value-rejected
- [x] Full `test_parser_create_extracts.py` suite: 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Source

Classic tabcmd's `--encrypt` handler (`app-tabcmd/src/.../commands/CreateExtracts.java:79-101`) accepts exactly `yes | y | no | n` (case-insensitive) and rejects anything else. Latest push (`fb14edc`) restores `y`/`n` — the Classic set — to the accepted values so ported scripts using the shortcuts keep working. Full tabcmd 2 set is now `yes | y | no | n | true | false | 1 | 0`: Classic's set intact, with `true`/`false`/`1`/`0` added on top as a forgiving superset for users typing boolean-shaped values.

Updated test coverage: 10 argparse tests (omitted / bare / yes / no / y / n / true / false / case-insensitive / bad-value-rejected).
