### PR TITLE
deps: pin urllib3>=2.6.0,<3 to match tableauserverclient

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "requests>=2.25,<3.0",
     "setuptools",
     "tableauserverclient==0.41",
-    "urllib3",
+    "urllib3>=2.6.0,<3",
 ]
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
## Motivation

urllib3 was unpinned in tabcmd. pip resolved a compatible version
transitively through TSC, but the tabcmd distribution itself declared
no compatibility bounds. If TSC bumps its urllib3 range in a future
release, tabcmd installs could resolve to versions TSC was never tested
against.

Match TSC's declared pin directly so any Python environment installing
tabcmd resolves the same urllib3 range TSC uses in CI.

## Behavior change

**For users:** none in practice; fresh install still resolves to
urllib3 2.6.3 today (same as before). Only the declared range changes.

The declared pin creates a duplicate source of truth with TSC. Long-term
solution is either drop this and rely on TSC's pin transitively, or
keep them in sync via a release checklist item.

## Test plan

- [x] No functional change; resolved urllib3 version unchanged on fresh
  install

🤖 Generated with [Claude Code](https://claude.com/claude-code)