### PR TITLE
deps: pin black==26.5.1 and mypy==2.3.0 to match TSC

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -28,7 +28,6 @@ def task_localize():
 
 
 def task_properties():
-
     """
     For all languages: a) Combines all existing properties files for a language into a single file called 'combined.tmp'
     and b) removes duplicates while preserving the original order of properties
@@ -377,7 +376,6 @@ def task_move_tabcmd_strings():
 
 
 def task_version():
-
     """Generates a metadata info file with current version to be bundled by pyinstaller"""
 
     def write_for_pyinstaller():
@@ -459,7 +457,6 @@ def uniquify_file(filename):
 
 
 def task_clean_all():
-
     """remove all generated files such as .po, .out, and pdf, csv etc that are not in the assets folder"""
 
     def clean_output_files():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,7 @@ packages = ["tabcmd"]
 tabcmd = ["tabcmd.locales/**/*.mo"]
 [tool.black]
 line-length = 120
-required-version = 22
-target-version = ['py310', 'py311']
+target-version = ['py310', 'py311', 'py312', 'py313', 'py314']
 extend-exclude = '^/bin/*'
 [tool.mypy]
 check_untyped_defs = true
@@ -53,9 +52,9 @@ dependencies = [
 ]
 [project.optional-dependencies]
 test = [
-    "black>=22,<23",
+    "black==26.5.1",
     "mock",
-    "mypy",
+    "mypy==2.3.0",
     "pytest>=7.0",
     "pytest-cov",
     "pytest-order",

--- a/tabcmd/execution/global_options.py
+++ b/tabcmd/execution/global_options.py
@@ -25,6 +25,7 @@ BUT filename, username -> filename, username in command/parser
 
 """
 
+
 # argparse does case-sensitive comparisons of string inputs by default
 # I want the user to be able to enter e.g. "viewer" and have it accepted as "Viewer"
 # https://stackoverflow.com/questions/56838004/
@@ -122,6 +123,7 @@ def set_encryption_option(parser):
 
 
 # item arguments: datasource, workbook, project, url ...
+
 
 # Matching classic tabcmd:
 # for some reason in parser.project, publish-samples it uses -n for destination project name

--- a/tabcmd/execution/localize.py
+++ b/tabcmd/execution/localize.py
@@ -51,6 +51,8 @@ def set_client_locale(lang: str = "", logger=None) -> Optional[Callable]:
 
 
 """Get absolute path to resource, works for unbundled (e.g dev) and when bundled by PyInstaller"""
+
+
 # https://stackoverflow.com/questions/7674790/bundling-data-files-with-pyinstaller-onefile/13790741#13790741
 def define_locale_dir(logger):
 

--- a/tabcmd/execution/logger_config.py
+++ b/tabcmd/execution/logger_config.py
@@ -14,6 +14,7 @@ FORMATS = {
     logging.DEBUG: "%(asctime)s %(levelname)-5s: (%(name)-10s %(filename)-10s: %(lineno)d): %(message)-30s",
 }
 
+
 # https://stackoverflow.com/questions/2183233/how-to-add-a-custom-loglevel-to-pythons-logging-facility
 def add_log_level(level_name, level_num, method_name=None):
     if not method_name:

--- a/tabcmd/version.py
+++ b/tabcmd/version.py
@@ -7,6 +7,8 @@ except PackageNotFoundError:
     # importlib.metadata is unavailable in PyInstaller bundles; fall back to the
     # _version.py file that setuptools_scm writes at build time.
     try:
-        from tabcmd._version import version
+        from tabcmd._version import version as _pyinstaller_version
+
+        version = _pyinstaller_version
     except ImportError:
         version = "0.0"

--- a/tests/assets/mock_data.py
+++ b/tests/assets/mock_data.py
@@ -93,6 +93,7 @@ def set_up_mock_server(mock_session):
     mock_server.any_item_type = getter
     mock_server.flows = getter
     mock_server.groups = getter
+
     # Ensure type name contains 'Projects' for filtering heuristics
     class ProjectsEndpoint:
         def __init__(self, ret):

--- a/tests/commands/test_listing_commands.py
+++ b/tests/commands/test_listing_commands.py
@@ -96,6 +96,7 @@ class ListCommandFunctionalTests(unittest.TestCase):
     @patch("tabcmd.execution.logger_config.log")
     def test_show_header_with_all_options(self, mock_log, mock_session, mock_translate):
         """Test header generation with all display options enabled"""
+
         # Mock the translation function to return the actual English strings
         def translate_side_effect(key):
             translations = {

--- a/tests/e2e/online_tests.py
+++ b/tests/e2e/online_tests.py
@@ -15,7 +15,6 @@ except ModuleNotFoundError:
 
 from tests.e2e import setup_e2e
 
-
 # to run this suite
 # pytest -q tests/e2e/online_tests.py
 # you can either run setup with a stored credentials file, or simply log in

--- a/tests/e2e/tests_integration.py
+++ b/tests/e2e/tests_integration.py
@@ -6,7 +6,6 @@ from tabcmd.commands.auth.session import Session
 from tabcmd.commands.server import Server
 from tabcmd.execution.logger_config import log
 
-
 try:
     from tests.e2e import credentials  # type: ignore
 except ImportError:
@@ -15,6 +14,7 @@ except ImportError:
 fakeserver = "http://SRVR"
 logging.disable(logging.ERROR)
 logger = log("tests_integration", "info")
+
 
 # these are integration tests because they don't just run a command, they call interior methods
 # pytest -v tests/e2e/integration_tests.py

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -49,8 +49,7 @@ class TestPythonMTabcmd(unittest.TestCase):
     def test_import_error_exits_one(self):
         # Inject a broken tabcmd.tabcmd into sys.modules before running __main__,
         # so the ImportError handler is exercised without relying on sys.path ordering.
-        script = textwrap.dedent(
-            """\
+        script = textwrap.dedent("""\
             import sys
             class _BrokenTabcmd:
                 def __getattr__(self, _):
@@ -58,8 +57,7 @@ class TestPythonMTabcmd(unittest.TestCase):
             sys.modules["tabcmd.tabcmd"] = _BrokenTabcmd()
             import runpy
             runpy.run_module("tabcmd", run_name="__main__")
-            """
-        )
+            """)
         with tempfile.TemporaryDirectory() as tmpdir:
             script_path = os.path.join(tmpdir, "run.py")
             with open(script_path, "w") as f:


### PR DESCRIPTION
## Motivation

The two Tableau-owned Python packages were on divergent dev-tool versions:

|           | tabcmd (before) | tabcmd (after) | TSC       |
|-----------|-----------------|----------------|-----------|
| black     | `>=22,<23`      | `==26.5.1`     | `==26.5.1` |
| mypy      | unpinned        | `==2.3.0`      | `==2.3.0`  |

Anyone working on both repos has to keep swapping black versions in
their local env. Match TSC's pins on the tabcmd side; the older repo is
the outlier.

## Behavior change

**For contributors:**

- `black 26` reformats 9 files (whitespace around decorators, blank
  lines after imports). No behavior change; all diffs are whitespace or
  trailing-comma noise.
- `[tool.black]` `target-version` bumped from py310-py311 to
  py310-py314, matching `requires-python = ">=3.10"` and the
  `classifiers` list.
- Dropped `required-version = 22` line from `[tool.black]`; the version
  pin in `[test]` is sufficient.

**mypy 2.3 caught one pre-existing issue** in `tabcmd/version.py`:
`from tabcmd._version import version` reimported the same name inside a
fallback branch, shadowing the `version: str = "unknown"` annotation.
Renamed the fallback import to `_pyinstaller_version`. Same string ends
up in `version`.

## Test plan

- [x] `black . --check` passes under black 26.5.1
- [x] `mypy tabcmd tests` passes with 0 errors under mypy 2.3.0
- [x] Full unit-test suite: 337 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)